### PR TITLE
Auth handlers grouped by issuer url

### DIFF
--- a/apis/authentication/v1alpha1/openidconnect_webhook.go
+++ b/apis/authentication/v1alpha1/openidconnect_webhook.go
@@ -108,6 +108,11 @@ func (r *OpenIDConnect) validate() field.ErrorList {
 			allErrs = append(allErrs, field.Invalid(field.NewPath("keys"), string(r.Spec.JWKS.Keys), "must be a valid base64 encoded JWKS"))
 		}
 	}
+
+	if len(r.Spec.ClientID) == 0 {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("clientID"), r.Spec.ClientID, "must not be empty"))
+	}
+
 	return allErrs
 }
 

--- a/apis/authentication/v1alpha1/openidconnect_webhook_test.go
+++ b/apis/authentication/v1alpha1/openidconnect_webhook_test.go
@@ -61,6 +61,7 @@ var _ = Describe("OpenidconnectWebhook", func() {
 	Context("create validation", func() {
 		BeforeEach(func() {
 			oidc.Spec.IssuerURL = "https://secure.com"
+			oidc.Spec.ClientID = "some-client-id"
 		})
 
 		It("should return error if issuer url is not starting with https", func() {
@@ -94,17 +95,26 @@ var _ = Describe("OpenidconnectWebhook", func() {
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("keys: Invalid value: \"dGVzdA==\": must be a valid base64 encoded JWKS"))
 		})
+
+		It("should return error for empty clientID", func() {
+			oidc.Spec.ClientID = ""
+			err := oidc.ValidateCreate()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("clientID: Invalid value: \"\": must not be empty"))
+		})
 	})
 
 	Context("update validation", func() {
 		BeforeEach(func() {
 			oidc.Spec.IssuerURL = "https://secure.com"
+			oidc.Spec.ClientID = "some-client-id"
 		})
 
 		It("should not return error if new oidc object is valid", func() {
 			newObj := OpenIDConnect{
 				Spec: OIDCAuthenticationSpec{
 					IssuerURL: "https://secure2.com",
+					ClientID:  "some-id",
 				},
 			}
 			err := newObj.ValidateUpdate(&oidc)
@@ -115,6 +125,7 @@ var _ = Describe("OpenidconnectWebhook", func() {
 			newObj := OpenIDConnect{
 				Spec: OIDCAuthenticationSpec{
 					IssuerURL: "http://notsecure.com",
+					ClientID:  "some-id",
 				},
 			}
 			err := newObj.ValidateUpdate(&oidc)

--- a/controllers/authentication/union_handler_test.go
+++ b/controllers/authentication/union_handler_test.go
@@ -1,0 +1,263 @@
+// SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package authentication
+
+import (
+	"sync"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("OpenidconnectWebhook", func() {
+
+	const (
+		issuer1     = "https://issuer1"
+		issuer2     = "https://issuer2"
+		issuer3     = "https://issuer3"
+		handlerKey1 = "my-unique-name-1"
+		handlerKey2 = "my-unique-name-2"
+		handlerKey3 = "my-unique-name-3"
+	)
+	var (
+		unionHandler *unionAuthTokenHandler
+	)
+
+	BeforeEach(func() {
+		unionHandler = &unionAuthTokenHandler{}
+	})
+
+	verifyHandler := func(u *unionAuthTokenHandler, issuer string, handlerKey string, auth *authenticatorInfo) {
+		val, ok := u.issuerHandlers.Load(issuer)
+		Expect(ok).To(BeTrue())
+
+		asMap, ok := val.(*sync.Map)
+		Expect(ok).To(BeTrue())
+
+		val, ok = asMap.Load(handlerKey)
+		Expect(ok).To(BeTrue())
+
+		handler, ok := val.(*authenticatorInfo)
+		Expect(ok).To(BeTrue())
+		Expect(handler).To(Equal(auth))
+
+		val, ok = u.nameIssuerMapping.Load(handlerKey)
+		Expect(ok).To(BeTrue())
+
+		url, ok := val.(string)
+		Expect(ok).To(BeTrue())
+		Expect(url).To(Equal(issuer))
+	}
+
+	verifyHandlerDoesNotExist := func(u *unionAuthTokenHandler, issuer string, handlerKey string) {
+		val, ok := u.issuerHandlers.Load(issuer)
+		Expect(ok).To(BeTrue())
+
+		asMap, ok := val.(*sync.Map)
+		Expect(ok).To(BeTrue())
+
+		_, ok = asMap.Load(handlerKey)
+		Expect(ok).To(BeFalse())
+	}
+
+	Context("Registering handlers", func() {
+		It("should successfully register a single handler", func() {
+			unionHandler.registerHandler(issuer1, handlerKey1, &authenticatorInfo{
+				Token: nil,
+				name:  "test",
+				uid:   "someid",
+			})
+
+			verifyHandler(unionHandler, issuer1, handlerKey1, &authenticatorInfo{
+				Token: nil,
+				name:  "test",
+				uid:   "someid",
+			})
+		})
+
+		It("should successfully register a single handler then change issuer", func() {
+			unionHandler.registerHandler(issuer1, handlerKey1, &authenticatorInfo{
+				Token: nil,
+				name:  "test",
+				uid:   "someid",
+			})
+
+			unionHandler.registerHandler(issuer2, handlerKey1, &authenticatorInfo{
+				Token: nil,
+				name:  "test",
+				uid:   "someid",
+			})
+
+			verifyHandlerDoesNotExist(unionHandler, issuer1, handlerKey1)
+			verifyHandler(unionHandler, issuer2, handlerKey1, &authenticatorInfo{
+				Token: nil,
+				name:  "test",
+				uid:   "someid",
+			})
+		})
+
+		It("should successfully register a single handler then delete it", func() {
+			unionHandler.registerHandler(issuer1, handlerKey1, &authenticatorInfo{
+				Token: nil,
+				name:  "test",
+				uid:   "someid",
+			})
+
+			unionHandler.deleteHandler(handlerKey1)
+
+			verifyHandlerDoesNotExist(unionHandler, issuer1, handlerKey1)
+		})
+
+		It("should successfully register a single handler change its issuer then delete it", func() {
+			unionHandler.registerHandler(issuer1, handlerKey1, &authenticatorInfo{
+				Token: nil,
+				name:  "test",
+				uid:   "someid",
+			})
+
+			unionHandler.registerHandler(issuer2, handlerKey1, &authenticatorInfo{
+				Token: nil,
+				name:  "test",
+				uid:   "someid",
+			})
+
+			verifyHandlerDoesNotExist(unionHandler, issuer1, handlerKey1)
+			verifyHandler(unionHandler, issuer2, handlerKey1, &authenticatorInfo{
+				Token: nil,
+				name:  "test",
+				uid:   "someid",
+			})
+
+			unionHandler.deleteHandler(handlerKey1)
+			verifyHandlerDoesNotExist(unionHandler, issuer2, handlerKey1)
+		})
+
+		It("should successfully register multiple handlers", func() {
+			unionHandler.registerHandler(issuer1, handlerKey1, &authenticatorInfo{
+				Token: nil,
+				name:  "test",
+				uid:   "someid",
+			})
+
+			unionHandler.registerHandler(issuer1, handlerKey2, &authenticatorInfo{
+				Token: nil,
+				name:  "test1",
+				uid:   "someid1",
+			})
+
+			unionHandler.registerHandler(issuer2, handlerKey3, &authenticatorInfo{
+				Token: nil,
+				name:  "test2",
+				uid:   "someid2",
+			})
+
+			verifyHandler(unionHandler, issuer1, handlerKey1, &authenticatorInfo{
+				Token: nil,
+				name:  "test",
+				uid:   "someid",
+			})
+
+			verifyHandler(unionHandler, issuer1, handlerKey2, &authenticatorInfo{
+				Token: nil,
+				name:  "test1",
+				uid:   "someid1",
+			})
+
+			verifyHandler(unionHandler, issuer2, handlerKey3, &authenticatorInfo{
+				Token: nil,
+				name:  "test2",
+				uid:   "someid2",
+			})
+		})
+
+		It("should successfully register multiple handlers then change issuer of one of them", func() {
+			unionHandler.registerHandler(issuer1, handlerKey1, &authenticatorInfo{
+				Token: nil,
+				name:  "test",
+				uid:   "someid",
+			})
+
+			unionHandler.registerHandler(issuer1, handlerKey2, &authenticatorInfo{
+				Token: nil,
+				name:  "test1",
+				uid:   "someid1",
+			})
+
+			unionHandler.registerHandler(issuer2, handlerKey3, &authenticatorInfo{
+				Token: nil,
+				name:  "test2",
+				uid:   "someid2",
+			})
+
+			verifyHandler(unionHandler, issuer1, handlerKey1, &authenticatorInfo{
+				Token: nil,
+				name:  "test",
+				uid:   "someid",
+			})
+
+			verifyHandler(unionHandler, issuer1, handlerKey2, &authenticatorInfo{
+				Token: nil,
+				name:  "test1",
+				uid:   "someid1",
+			})
+
+			verifyHandler(unionHandler, issuer2, handlerKey3, &authenticatorInfo{
+				Token: nil,
+				name:  "test2",
+				uid:   "someid2",
+			})
+
+			unionHandler.registerHandler(issuer2, handlerKey2, &authenticatorInfo{
+				Token: nil,
+				name:  "test1-new",
+				uid:   "someid1-new",
+			})
+
+			verifyHandlerDoesNotExist(unionHandler, issuer1, handlerKey2)
+
+			verifyHandler(unionHandler, issuer2, handlerKey2, &authenticatorInfo{
+				Token: nil,
+				name:  "test1-new",
+				uid:   "someid1-new",
+			})
+		})
+
+		It("should successfully register multiple handlers then delete one of them", func() {
+			unionHandler.registerHandler(issuer1, handlerKey1, &authenticatorInfo{
+				Token: nil,
+				name:  "test",
+				uid:   "someid",
+			})
+
+			unionHandler.registerHandler(issuer1, handlerKey2, &authenticatorInfo{
+				Token: nil,
+				name:  "test1",
+				uid:   "someid1",
+			})
+
+			unionHandler.registerHandler(issuer2, handlerKey3, &authenticatorInfo{
+				Token: nil,
+				name:  "test2",
+				uid:   "someid2",
+			})
+
+			unionHandler.deleteHandler(handlerKey2)
+
+			verifyHandler(unionHandler, issuer1, handlerKey1, &authenticatorInfo{
+				Token: nil,
+				name:  "test",
+				uid:   "someid",
+			})
+
+			verifyHandlerDoesNotExist(unionHandler, issuer1, handlerKey2)
+
+			verifyHandler(unionHandler, issuer2, handlerKey3, &authenticatorInfo{
+				Token: nil,
+				name:  "test2",
+				uid:   "someid2",
+			})
+		})
+	})
+})

--- a/test/integration/integration_suite_test.go
+++ b/test/integration/integration_suite_test.go
@@ -52,9 +52,11 @@ const (
 	timeout                   = time.Second * 10
 	interval                  = time.Millisecond * 250
 	defaultNamespaceName      = "default"
+	differentNamespaceName    = "different"
 	oidcName1                 = "test1"
 	oidcName2                 = "test2"
 	oidcName3                 = "test3"
+	oidcName4                 = "test4"
 	wellKnownResponseTemplate = `{
 		"issuer": "%[1]s",
 		"authorization_endpoint": "%[1]s/auth",
@@ -234,6 +236,28 @@ func setupCustomRecources() {
 			},
 		},
 	}
+
+	// This is a configuration similar to openidconnect1 but with different client id
+	openidconnect4 := &authenticationv1alpha1.OpenIDConnect{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "authentication.gardener.cloud/v1alpha1",
+			Kind:       "OpenIDConnect",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      oidcName4,
+			Namespace: defaultNamespaceName,
+		},
+		Spec: authenticationv1alpha1.OIDCAuthenticationSpec{
+			IssuerURL:     fmt.Sprintf("https://localhost:%v", idpServerPort1),
+			ClientID:      "different-client-id",
+			UsernameClaim: &userNameClaim1,
+			CABundle:      ca,
+		},
+	}
+
+	Expect(k8sClient.Create(ctx, openidconnect4)).Should(Succeed())
+	waitForOIDCResourceToBecomeAvailable(oidcName4, defaultNamespaceName)
+
 	Expect(k8sClient.Create(ctx, openidconnect1)).Should(Succeed())
 	waitForOIDCResourceToBecomeAvailable(oidcName1, defaultNamespaceName)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR groups the authentication handlers by issuer url so that the group of handlers for the given issuer is retrieved in O(1). Depends on #19 
**Which issue(s) this PR fixes**:
Fixes #3 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
