### PR TITLE
Add a helm chart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-
 # Binaries for programs and plugins
 *.exe
 *.exe~
@@ -24,3 +23,4 @@ testbin
 *.swo
 *~
 dive.log
+/tmp

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,9 @@ else
 GOBIN=$(shell go env GOBIN)
 endif
 
+# helm
+include helm.mk
+
 all: build
 
 ##@ General
@@ -74,4 +77,3 @@ test:
 .PHONY: cleanup-test-env
 cleanup-test-env:
 	@.hack/local/cleanup-test-env.sh
-

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ help: ## Display this help.
 
 manifests: tools-image ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	docker run --rm --name=oidc-tools -v $(shell pwd):/workspace tools:latest controller-gen $(CRD_OPTIONS) rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+	cp -u config/crd/bases/* helm/oidc-webhook-authenticator/crds/.
 
 generate: tools-image ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
 	docker run --rm --name=oidc-tools -v $(shell pwd):/workspace tools:latest controller-gen object:headerFile="hack/boilerplate.go.txt" paths="./..."

--- a/helm.mk
+++ b/helm.mk
@@ -1,0 +1,25 @@
+HELM				?= helm3 # expected to be helm v3
+HELM_CHART_DIR		?= helm/oidc-webhook-authenticator
+HELM_NAMESPACE		?= oidc-webhook-authenticator-system
+HELM_RELEASE_NAME	?= oidc-wh
+HELM_OUTPUT_DIR		?= tmp
+
+helm-clean: ## Clean up templated helm chart
+	@rm -Rf $(HELM_OUTPUT_DIR)
+
+helm-lint: ## Run helm lint against helm chart.
+	@$(HELM) lint $(HELM_CHART_DIR)
+
+helm-install: ## Run helm upgrade --install.
+	$(HELM) upgrade --install $(HELM_RELEASE_NAME) --namespace $(HELM_NAMESPACE) $(HELM_CHART_DIR)
+
+helm-uninstall: ## Run helm uninstall.
+	$(HELM) uninstall --namespace $(HELM_NAMESPACE) $(HELM_RELEASE_NAME)
+
+helm-package: ## Run helm package
+	$(HELM) package --dependency-update $(HELM_CHART_DIR)
+
+helm-template: helm-clean ## Run helm template
+	@mkdir -p $(HELM_OUTPUT_DIR)
+	@$(HELM) template $(HELM_RELEASE_NAME) $(HELM_CHART_DIR) --namespace $(HELM_NAMESPACE) --output-dir $(HELM_OUTPUT_DIR)
+

--- a/helm/oidc-webhook-authenticator/.helmignore
+++ b/helm/oidc-webhook-authenticator/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm/oidc-webhook-authenticator/Chart.yaml
+++ b/helm/oidc-webhook-authenticator/Chart.yaml
@@ -21,4 +21,4 @@ version: 0.0.1
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.0.1"
+appVersion: "v0.1.0-dev-4d990cc640e15eb7e391da9527671bc139265a89"

--- a/helm/oidc-webhook-authenticator/Chart.yaml
+++ b/helm/oidc-webhook-authenticator/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: oidc-webhook-authenticator
+description: A Helm chart for Kubernetes the OpenID Connect Webhook Authenticator. It allows Kubernetes cluster administrators to dynamically register new OpenID Connect providers in their clusters to use for kube-apiserver authentication.
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.0.1
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "0.0.1"

--- a/helm/oidc-webhook-authenticator/crds/authentication.gardener.cloud_openidconnects.yaml
+++ b/helm/oidc-webhook-authenticator/crds/authentication.gardener.cloud_openidconnects.yaml
@@ -1,0 +1,176 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.1
+  creationTimestamp: null
+  name: openidconnects.authentication.gardener.cloud
+spec:
+  group: authentication.gardener.cloud
+  names:
+    kind: OpenIDConnect
+    listKind: OpenIDConnectList
+    plural: openidconnects
+    shortNames:
+    - oidc
+    - oidcs
+    singular: openidconnect
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - description: Issuer is the URL the provider signs ID Tokens as
+      jsonPath: .spec.issuerURL
+      name: Issuer
+      type: string
+    - description: ClientID is the audience for which this ID Token is issued for
+      jsonPath: .spec.clientID
+      name: Client ID
+      type: string
+    - description: Username claim is the JWT field to use as the user's username
+      jsonPath: .spec.usernameClaim
+      name: Username Claim
+      type: string
+    - description: Groups claim is the JWT field to use as the user's groups
+      jsonPath: .spec.groupsClaim
+      name: Groups Claim
+      type: string
+    - description: CreationTimestamp is a timestamp representing the server time when
+        this object was created
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: OpenIDConnect allows to dynamically register OpenID Connect providers
+          used to authenticate against the kube-apiserver.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: OIDCAuthenticationSpec defines the desired state of OpenIDConnect
+            properties:
+              caBundle:
+                description: '`caBundle` is a PEM encoded CA bundle which will be
+                  used to validate the webhook''s server certificate. If unspecified,
+                  system trust roots on the apiserver are used.'
+                format: byte
+                type: string
+              clientID:
+                description: "ClientID is the audience for which the JWT must be issued
+                  for, the \"aud\" field. \n The plugin supports the \"authorized
+                  party\" OpenID Connect claim, which allows specialized providers
+                  to issue tokens to a client for a different client. See: https://openid.net/specs/openid-connect-core-1_0.html#IDToken"
+                minLength: 1
+                type: string
+              groupsClaim:
+                default: groups
+                description: GroupsClaim, if specified, causes the OIDCAuthenticator
+                  to try to populate the user's groups with an ID Token field. If
+                  the GroupsClaim field is present in an ID Token the value must be
+                  a string or list of strings.
+                type: string
+              groupsPrefix:
+                description: "GroupsPrefix, if specified, causes claims mapping to
+                  group names to be prefixed with the value. A value \"oidc:\" would
+                  result in groups like \"oidc:engineering\" and \"oidc:marketing\".
+                  \n If not provided, the prefix defaults to \"( .metadata.name )/\".
+                  The value \"-\"\" can be used to disable all prefixing."
+                type: string
+              issuerURL:
+                description: "IssuerURL is the URL the provider signs ID Tokens as.
+                  This will be the \"iss\" field of all tokens produced by the provider
+                  and is used for configuration discovery. \n The URL is usually the
+                  provider's URL without a path, for example \"https://foo.com\" or
+                  \"https://example.com\". \n The provider must implement configuration
+                  discovery. See: https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig"
+                pattern: ^https:\/\/
+                type: string
+              jwks:
+                description: JWKS if specified, provides an option to specify JWKS
+                  keys offline.
+                properties:
+                  distributedClaims:
+                    default: true
+                    description: '`distributedClaims` enables the OIDCAuthenticator
+                      to return references to claims that are asserted by external
+                      Claims providers.'
+                    type: boolean
+                  keys:
+                    description: '`keys` is a base64 encoded JSON webkey Set. If specified,
+                      the OIDCAuthenticator skips the request to the issuer''s jwks_uri
+                      endpoint to retrieve the keys.'
+                    format: byte
+                    type: string
+                type: object
+              requiredClaims:
+                additionalProperties:
+                  type: string
+                description: RequiredClaims, if specified, causes the OIDCAuthenticator
+                  to verify that all the required claims key value pairs are present
+                  in the ID Token.
+                type: object
+              supportedSigningAlgs:
+                default:
+                - RS256
+                description: "SupportedSigningAlgs sets the accepted set of JOSE signing
+                  algorithms that can be used by the provider to sign tokens. \n https://tools.ietf.org/html/rfc7518#section-3.1
+                  \n This value defaults to RS256, the value recommended by the OpenID
+                  Connect spec: \n https://openid.net/specs/openid-connect-core-1_0.html#IDTokenValidation"
+                items:
+                  description: SigningAlgorithm is JOSE asymmetric signing algorithm
+                    value as defined by RFC 7518
+                  enum:
+                  - RS256
+                  - RS384
+                  - RS512
+                  - ES256
+                  - ES384
+                  - ES512
+                  - PS256
+                  - PS384
+                  - PS512
+                  type: string
+                type: array
+              usernameClaim:
+                default: sub
+                description: UsernameClaim is the JWT field to use as the user's username.
+                type: string
+              usernamePrefix:
+                description: "UsernamePrefix, if specified, causes claims mapping
+                  to username to be prefix with the provided value. A value \"oidc:\"
+                  would result in usernames like \"oidc:john\". \n If not provided,
+                  the prefix defaults to \"( .metadata.name )/\". The value \"-\"\"
+                  can be used to disable all prefixing."
+                type: string
+            required:
+            - clientID
+            - issuerURL
+            type: object
+          status:
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/helm/oidc-webhook-authenticator/templates/_helpers.tpl
+++ b/helm/oidc-webhook-authenticator/templates/_helpers.tpl
@@ -15,7 +15,7 @@ If release name contains chart name it will be used as a full name.
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
 {{- $name := default .Chart.Name .Values.nameOverride }}
-{{- printf "gardener.cloud:authentication:%s" $name | trunc 63 | trimSuffix "-" }}
+{{- printf "gardener-cloud-authentication-%s" $name | trunc 63 | trimSuffix "-" }}
 {{- end }}
 {{- end }}
 

--- a/helm/oidc-webhook-authenticator/templates/_helpers.tpl
+++ b/helm/oidc-webhook-authenticator/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "oidc-webhook-authenticator.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "oidc-webhook-authenticator.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "oidc-webhook-authenticator.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "oidc-webhook-authenticator.labels" -}}
+helm.sh/chart: {{ include "oidc-webhook-authenticator.chart" . }}
+{{ include "oidc-webhook-authenticator.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "oidc-webhook-authenticator.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "oidc-webhook-authenticator.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "oidc-webhook-authenticator.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "oidc-webhook-authenticator.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/helm/oidc-webhook-authenticator/templates/_helpers.tpl
+++ b/helm/oidc-webhook-authenticator/templates/_helpers.tpl
@@ -15,11 +15,7 @@ If release name contains chart name it will be used as a full name.
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
 {{- $name := default .Chart.Name .Values.nameOverride }}
-{{- if contains $name .Release.Name }}
-{{- .Release.Name | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
-{{- end }}
+{{- printf "gardener.cloud:authentication:%s" $name | trunc 63 | trimSuffix "-" }}
 {{- end }}
 {{- end }}
 

--- a/helm/oidc-webhook-authenticator/templates/certificate.yaml
+++ b/helm/oidc-webhook-authenticator/templates/certificate.yaml
@@ -1,0 +1,21 @@
+{{ if .Values.certificate.certmanager }}
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: selfsigned-issuer
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "oidc-webhook-authenticator.fullname" . }}
+spec:
+  dnsNames:
+  - {{ include "oidc-webhook-authenticator.fullname" . }}.{{ .Release.Namespace }}.svc
+  - {{ include "oidc-webhook-authenticator.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: selfsigned-issuer
+  secretName: {{ .Values.certificate.secretName | default (include "oidc-webhook-authenticator.fullname" .) }}
+{{ end }}

--- a/helm/oidc-webhook-authenticator/templates/clusterrole.yaml
+++ b/helm/oidc-webhook-authenticator/templates/clusterrole.yaml
@@ -1,0 +1,27 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: gardener.cloud:authentication:oidc-webhook-authenticator
+  labels:
+    {{- include "oidc-webhook-authenticator.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
+  - authentication.gardener.cloud
+  resources:
+  - openidconnects
+  verbs:
+  - get
+  - list
+  - watch

--- a/helm/oidc-webhook-authenticator/templates/clusterrole.yaml
+++ b/helm/oidc-webhook-authenticator/templates/clusterrole.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: gardener.cloud:authentication:oidc-webhook-authenticator
+  name: {{ include "oidc-webhook-authenticator.fullname" . }}
   labels:
     {{- include "oidc-webhook-authenticator.labels" . | nindent 4 }}
 rules:

--- a/helm/oidc-webhook-authenticator/templates/clusterrolebinding.yaml
+++ b/helm/oidc-webhook-authenticator/templates/clusterrolebinding.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: gardener.cloud:authentication:oidc-webhook-authenticator
+  name: {{ include "oidc-webhook-authenticator.fullname" . }}
   labels:
     {{- include "oidc-webhook-authenticator.labels" . | nindent 4 }}
 roleRef:

--- a/helm/oidc-webhook-authenticator/templates/clusterrolebinding.yaml
+++ b/helm/oidc-webhook-authenticator/templates/clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: gardener.cloud:authentication:oidc-webhook-authenticator
+  labels:
+    {{- include "oidc-webhook-authenticator.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: gardener.cloud:authentication:oidc-webhook-authenticator
+subjects:
+- kind: ServiceAccount
+  name: {{ include "oidc-webhook-authenticator.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}

--- a/helm/oidc-webhook-authenticator/templates/deployment.yaml
+++ b/helm/oidc-webhook-authenticator/templates/deployment.yaml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "oidc-webhook-authenticator.fullname" . }}
+  labels:
+    {{- include "oidc-webhook-authenticator.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "oidc-webhook-authenticator.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "oidc-webhook-authenticator.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "oidc-webhook-authenticator.serviceAccountName" . }}
+      hostNetwork: true # needed because kube-apiserver cannot use kube-dns
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: authenticator
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+          - --tls-cert-file=/var/run/certs/tls.crt
+          - --tls-private-key-file=/var/run/certs/tls.key
+          - --v=6
+          ports:
+            - name: https
+              containerPort: 10443
+              protocol: TCP
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+          - name: certs
+            mountPath: /var/run/certs
+      volumes:
+      - name: certs
+        secret:
+          secretName: {{ .Values.certificatesSecretName }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/helm/oidc-webhook-authenticator/templates/deployment.yaml
+++ b/helm/oidc-webhook-authenticator/templates/deployment.yaml
@@ -50,7 +50,7 @@ spec:
       volumes:
       - name: certs
         secret:
-          secretName: {{ .Values.certificatesSecretName }}
+          secretName: {{ .Values.certificate.secretName | default (include "oidc-webhook-authenticator.fullname" .) }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/oidc-webhook-authenticator/templates/hpa.yaml
+++ b/helm/oidc-webhook-authenticator/templates/hpa.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "oidc-webhook-authenticator.fullname" . }}
+  labels:
+    {{- include "oidc-webhook-authenticator.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "oidc-webhook-authenticator.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/helm/oidc-webhook-authenticator/templates/oidc-config.yaml
+++ b/helm/oidc-webhook-authenticator/templates/oidc-config.yaml
@@ -1,0 +1,9 @@
+{{- range $i, $oidc := .Values.oidc }}
+apiVersion: authentication.gardener.cloud/v1alpha1
+kind: OpenIDConnect
+metadata:
+  name: {{ required ".Values.oidc.name must be provided" $oidc.name }}
+spec:
+  {{- toYaml $oidc.values | nindent 2 }}
+---
+{{ end -}}

--- a/helm/oidc-webhook-authenticator/templates/rolebinding.yaml
+++ b/helm/oidc-webhook-authenticator/templates/rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: gardener.cloud:authentication:oidc-webhook-authenticator
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+- kind: ServiceAccount
+  name: {{ include "oidc-webhook-authenticator.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}

--- a/helm/oidc-webhook-authenticator/templates/rolebinding.yaml
+++ b/helm/oidc-webhook-authenticator/templates/rolebinding.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: gardener.cloud:authentication:oidc-webhook-authenticator
+  name: {{ include "oidc-webhook-authenticator.fullname" . }}
   namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/helm/oidc-webhook-authenticator/templates/service.yaml
+++ b/helm/oidc-webhook-authenticator/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "oidc-webhook-authenticator.fullname" . }}
+  labels:
+    {{- include "oidc-webhook-authenticator.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: https
+      protocol: TCP
+      name: https
+  selector:
+    {{- include "oidc-webhook-authenticator.selectorLabels" . | nindent 4 }}

--- a/helm/oidc-webhook-authenticator/templates/serviceaccount.yaml
+++ b/helm/oidc-webhook-authenticator/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "oidc-webhook-authenticator.serviceAccountName" . }}
+  labels:
+    {{- include "oidc-webhook-authenticator.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/helm/oidc-webhook-authenticator/values.yaml
+++ b/helm/oidc-webhook-authenticator/values.yaml
@@ -66,4 +66,60 @@ tolerations: []
 affinity: {}
 
 # Name of the secret containing the certificates for the oidc-webhook-authenticator
-certificatesSecretName: oidc-webhook-authenticator-certificates
+certificatesSecretName: gardener.cloud:authentication:oidc-webhook-authenticator
+
+oidc:
+  - name: "foo"
+    values:
+      # IssuerURL is the URL the provider signs ID Tokens as.
+      # This will be the "iss" field of all tokens produced by the provider
+      # and is used for configuration discovery. The URL is usually the
+      # provider's URL without a path, for example "https://foo.com" or
+      # "https://example.com". The provider must implement configuration
+      # discovery. See: https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig
+      issuerURL: "https://foo.bar" # required
+      # ClientID is the audience for which the JWT must be issued
+      # for, the "aud" field. The plugin supports the "authorized
+      # party" OpenID Connect claim, which allows specialized providers
+      # to issue tokens to a client for a different client. See: https://openid.net/specs/openid-connect-core-1_0.html#IDToken
+      clientID: "some-client-id" # required
+      # UsernameClaim is the JWT field to use as the user's username.
+      # usernameClaim: ""
+      # UsernamePrefix, if specified, causes claims mapping
+      # to username to be prefix with the provided value. A value "oidc:"
+      # would result in usernames like "oidc:john". If not provided,
+      # the prefix defaults to "( .metadata.name )/". The value "-""
+      # can be used to disable all prefixing.
+      # usernamePrefix: "-"
+      # GroupsClaim, if specified, causes the OIDCAuthenticator
+      # to try to populate the user's groups with an ID Token field. If
+      # the GroupsClaim field is present in an ID Token the value must be
+      # a string or list of strings.
+      # groupsClaim: ""
+      # GroupsPrefix, if specified, causes claims mapping to
+      # group names to be prefixed with the value. A value "oidc:" would
+      # result in groups like "oidc:engineering" and "oidc:marketing".
+      # If not provided, the prefix defaults to "( .metadata.name )/".
+      # The value "-"" can be used to disable all prefixing."
+      # groupsPrefix: ""
+      # `caBundle` is a PEM encoded CA bundle which will be
+      # used to validate the webhook''s server certificate. If unspecified,
+      # system trust roots on the apiserver are used.
+      # caBundle: ""
+      # JWKS if specified, provides an option to specify JWKS
+      # keys offline.
+      # jwks: {}
+        # `keys` is a base64 encoded JSON webkey Set. If specified,
+        # the OIDCAuthenticator skips the request to the issuer''s jwks_uri
+        # endpoint to retrieve the keys.'
+        # keys: ""
+      # RequiredClaims, if specified, causes the OIDCAuthenticator
+      # to verify that all the required claims key value pairs are present
+      # in the ID Token.
+      # requiredClaims: {}
+        # baz: bar
+      # SupportedSigningAlgs sets the accepted set of JOSE signing
+      # algorithms that can be used by the provider to sign tokens. https://tools.ietf.org/html/rfc7518#section-3.1
+      # This value defaults to RS256, the value recommended by the OpenID
+      # Connect spec: https://openid.net/specs/openid-connect-core-1_0.html#IDTokenValidation
+      # supportedSigningAlgs:

--- a/helm/oidc-webhook-authenticator/values.yaml
+++ b/helm/oidc-webhook-authenticator/values.yaml
@@ -5,7 +5,7 @@
 replicaCount: 1
 
 image:
-  repository: oidc-webhook-authenticator
+  repository: eu.gcr.io/gardener-project/gardener/oidc-webhook-authenticator
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""

--- a/helm/oidc-webhook-authenticator/values.yaml
+++ b/helm/oidc-webhook-authenticator/values.yaml
@@ -66,7 +66,7 @@ tolerations: []
 affinity: {}
 
 # Name of the secret containing the certificates for the oidc-webhook-authenticator
-certificatesSecretName: gardener.cloud:authentication:oidc-webhook-authenticator
+certificatesSecretName: oidc-webhook-authenticator
 
 oidc:
   - name: "foo"

--- a/helm/oidc-webhook-authenticator/values.yaml
+++ b/helm/oidc-webhook-authenticator/values.yaml
@@ -1,0 +1,69 @@
+# Default values for oidc-webhook-authenticator.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: oidc-webhook-authenticator
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: ClusterIP
+  port: 443
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+# Name of the secret containing the certificates for the oidc-webhook-authenticator
+certificatesSecretName: oidc-webhook-authenticator-certificates

--- a/helm/oidc-webhook-authenticator/values.yaml
+++ b/helm/oidc-webhook-authenticator/values.yaml
@@ -65,8 +65,12 @@ tolerations: []
 
 affinity: {}
 
-# Name of the secret containing the certificates for the oidc-webhook-authenticator
-certificatesSecretName: oidc-webhook-authenticator
+certificate:
+  # Use cert-manager to issue the certificate automatically
+  certmanager: true
+  # Name of the secret containing the certificates for the oidc-webhook-authenticator
+  # Auto-generated if empty.
+  secretName: ""
 
 oidc:
   - name: "foo"


### PR DESCRIPTION
**What this PR does / why we need it**:
It is currently pretty complicated to rollout the service. This PR adds a helm chart to easily deploy the oidc-webhook-authenticator.