### PR TITLE
Added charts for installation of the oidc webhook authenticator

### DIFF
--- a/charts/oidc-webhook-authenticator/.helmignore
+++ b/charts/oidc-webhook-authenticator/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/oidc-webhook-authenticator/Chart.yaml
+++ b/charts/oidc-webhook-authenticator/Chart.yaml
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for Kubernetes the OpenID Connect Webhook Authenticator. It allows Kubernetes cluster administrators to dynamically register new OpenID Connect providers in their clusters to use for kube-apiserver authentication.
+name: oidc-webhook-authenticator
+version: 0.1.0

--- a/charts/oidc-webhook-authenticator/charts/application/Chart.yaml
+++ b/charts/oidc-webhook-authenticator/charts/application/Chart.yaml
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+description: A Helm chart to deploy the oidc-webhook-authenticator application related resources
+name: application
+version: 0.1.0

--- a/charts/oidc-webhook-authenticator/charts/application/templates/_helpers.tpl
+++ b/charts/oidc-webhook-authenticator/charts/application/templates/_helpers.tpl
@@ -1,0 +1,27 @@
+{{- define "oidc-webhook-authenticator.name" -}}
+oidc-webhook-authenticator
+{{- end -}}
+
+{{-  define "oidc-webhook-authenticator.webhook-kubeconfig" -}}
+apiVersion: v1
+kind: Config
+clusters:
+  - name: {{ include "oidc-webhook-authenticator.name" . }}
+    cluster:
+{{- if .Values.virtualGarden.enabled }}
+      server: {{ printf "https://%s.%s/validate-token" (include "oidc-webhook-authenticator.name" .) (.Release.Namespace) }}
+{{- else }}
+      server: {{ printf "https://%s/validate-token" (include "oidc-webhook-authenticator.name" .) }}
+{{- end }}
+      certificate-authority-data: {{ required ".Values.webhookConfig.caBundle is required" (b64enc .Values.webhookConfig.caBundle) }}
+users:
+  - name: {{ include "oidc-webhook-authenticator.name" . }}
+    user:
+      tokenFile: /var/run/secrets/oidc-webhook-tokens/kube-apiserver-token
+current-context: {{ include "oidc-webhook-authenticator.name" . }}
+contexts:
+  - name: {{ include "oidc-webhook-authenticator.name" . }}
+    context:
+      cluster: {{ include "oidc-webhook-authenticator.name" . }}
+      user: {{ include "oidc-webhook-authenticator.name" . }}
+{{- end }}

--- a/charts/oidc-webhook-authenticator/charts/application/templates/authentication.gardener.cloud_openidconnects.yaml
+++ b/charts/oidc-webhook-authenticator/charts/application/templates/authentication.gardener.cloud_openidconnects.yaml
@@ -1,0 +1,179 @@
+# SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.1
+  creationTimestamp: null
+  name: openidconnects.authentication.gardener.cloud
+spec:
+  group: authentication.gardener.cloud
+  names:
+    kind: OpenIDConnect
+    listKind: OpenIDConnectList
+    plural: openidconnects
+    shortNames:
+    - oidc
+    - oidcs
+    singular: openidconnect
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - description: Issuer is the URL the provider signs ID Tokens as
+      jsonPath: .spec.issuerURL
+      name: Issuer
+      type: string
+    - description: ClientID is the audience for which this ID Token is issued for
+      jsonPath: .spec.clientID
+      name: Client ID
+      type: string
+    - description: Username claim is the JWT field to use as the user's username
+      jsonPath: .spec.usernameClaim
+      name: Username Claim
+      type: string
+    - description: Groups claim is the JWT field to use as the user's groups
+      jsonPath: .spec.groupsClaim
+      name: Groups Claim
+      type: string
+    - description: CreationTimestamp is a timestamp representing the server time when
+        this object was created
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: OpenIDConnect allows to dynamically register OpenID Connect providers
+          used to authenticate against the kube-apiserver.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: OIDCAuthenticationSpec defines the desired state of OpenIDConnect
+            properties:
+              caBundle:
+                description: '`caBundle` is a PEM encoded CA bundle which will be
+                  used to validate the webhook''s server certificate. If unspecified,
+                  system trust roots on the apiserver are used.'
+                format: byte
+                type: string
+              clientID:
+                description: "ClientID is the audience for which the JWT must be issued
+                  for, the \"aud\" field. \n The plugin supports the \"authorized
+                  party\" OpenID Connect claim, which allows specialized providers
+                  to issue tokens to a client for a different client. See: https://openid.net/specs/openid-connect-core-1_0.html#IDToken"
+                minLength: 1
+                type: string
+              groupsClaim:
+                default: groups
+                description: GroupsClaim, if specified, causes the OIDCAuthenticator
+                  to try to populate the user's groups with an ID Token field. If
+                  the GroupsClaim field is present in an ID Token the value must be
+                  a string or list of strings.
+                type: string
+              groupsPrefix:
+                description: "GroupsPrefix, if specified, causes claims mapping to
+                  group names to be prefixed with the value. A value \"oidc:\" would
+                  result in groups like \"oidc:engineering\" and \"oidc:marketing\".
+                  \n If not provided, the prefix defaults to \"( .metadata.name )/\".
+                  The value \"-\"\" can be used to disable all prefixing."
+                type: string
+              issuerURL:
+                description: "IssuerURL is the URL the provider signs ID Tokens as.
+                  This will be the \"iss\" field of all tokens produced by the provider
+                  and is used for configuration discovery. \n The URL is usually the
+                  provider's URL without a path, for example \"https://foo.com\" or
+                  \"https://example.com\". \n The provider must implement configuration
+                  discovery. See: https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig"
+                pattern: ^https:\/\/
+                type: string
+              jwks:
+                description: JWKS if specified, provides an option to specify JWKS
+                  keys offline.
+                properties:
+                  distributedClaims:
+                    default: true
+                    description: '`distributedClaims` enables the OIDCAuthenticator
+                      to return references to claims that are asserted by external
+                      Claims providers.'
+                    type: boolean
+                  keys:
+                    description: '`keys` is a base64 encoded JSON webkey Set. If specified,
+                      the OIDCAuthenticator skips the request to the issuer''s jwks_uri
+                      endpoint to retrieve the keys.'
+                    format: byte
+                    type: string
+                type: object
+              requiredClaims:
+                additionalProperties:
+                  type: string
+                description: RequiredClaims, if specified, causes the OIDCAuthenticator
+                  to verify that all the required claims key value pairs are present
+                  in the ID Token.
+                type: object
+              supportedSigningAlgs:
+                default:
+                - RS256
+                description: "SupportedSigningAlgs sets the accepted set of JOSE signing
+                  algorithms that can be used by the provider to sign tokens. \n https://tools.ietf.org/html/rfc7518#section-3.1
+                  \n This value defaults to RS256, the value recommended by the OpenID
+                  Connect spec: \n https://openid.net/specs/openid-connect-core-1_0.html#IDTokenValidation"
+                items:
+                  description: SigningAlgorithm is JOSE asymmetric signing algorithm
+                    value as defined by RFC 7518
+                  enum:
+                  - RS256
+                  - RS384
+                  - RS512
+                  - ES256
+                  - ES384
+                  - ES512
+                  - PS256
+                  - PS384
+                  - PS512
+                  type: string
+                type: array
+              usernameClaim:
+                default: sub
+                description: UsernameClaim is the JWT field to use as the user's username.
+                type: string
+              usernamePrefix:
+                description: "UsernamePrefix, if specified, causes claims mapping
+                  to username to be prefix with the provided value. A value \"oidc:\"
+                  would result in usernames like \"oidc:john\". \n If not provided,
+                  the prefix defaults to \"( .metadata.name )/\". The value \"-\"\"
+                  can be used to disable all prefixing."
+                type: string
+            required:
+            - clientID
+            - issuerURL
+            type: object
+          status:
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/charts/oidc-webhook-authenticator/charts/application/templates/rbac.yaml
+++ b/charts/oidc-webhook-authenticator/charts/application/templates/rbac.yaml
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "oidc-webhook-authenticator.name" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "oidc-webhook-authenticator.name" . }}
+rules:
+- apiGroups:
+  - authentication.gardener.cloud
+  resources:
+  - openidconnects
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "oidc-webhook-authenticator.name" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "oidc-webhook-authenticator.name" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "oidc-webhook-authenticator.name" . }}
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: {{ include "oidc-webhook-authenticator.name" . }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "oidc-webhook-authenticator.name" . }}
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: {{ include "oidc-webhook-authenticator.name" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: {{ include "oidc-webhook-authenticator.name" . }}

--- a/charts/oidc-webhook-authenticator/charts/application/values.yaml
+++ b/charts/oidc-webhook-authenticator/charts/application/values.yaml
@@ -1,0 +1,1 @@
+../../values.yaml

--- a/charts/oidc-webhook-authenticator/charts/runtime/Chart.yaml
+++ b/charts/oidc-webhook-authenticator/charts/runtime/Chart.yaml
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+description: A Helm chart to deploy the oidc-webhook-authenticator runtime related resources
+name: runtime
+version: 0.1.0

--- a/charts/oidc-webhook-authenticator/charts/runtime/templates/_helpers.tpl
+++ b/charts/oidc-webhook-authenticator/charts/runtime/templates/_helpers.tpl
@@ -1,0 +1,27 @@
+{{- define "oidc-webhook-authenticator.name" -}}
+oidc-webhook-authenticator
+{{- end -}}
+
+{{-  define "oidc-webhook-authenticator.webhook-kubeconfig" -}}
+apiVersion: v1
+kind: Config
+clusters:
+  - name: {{ include "oidc-webhook-authenticator.name" . }}
+    cluster:
+{{- if .Values.virtualGarden.enabled }}
+      server: {{ printf "https://%s.%s/validate-token" (include "oidc-webhook-authenticator.name" .) (.Release.Namespace) }}
+{{- else }}
+      server: {{ printf "https://%s/validate-token" (include "oidc-webhook-authenticator.name" .) }}
+{{- end }}
+      certificate-authority-data: {{ required ".Values.webhookConfig.caBundle is required" (b64enc .Values.webhookConfig.caBundle) }}
+users:
+  - name: {{ include "oidc-webhook-authenticator.name" . }}
+    user:
+      tokenFile: /var/run/secrets/oidc-webhook-tokens/kube-apiserver-token
+current-context: {{ include "oidc-webhook-authenticator.name" . }}
+contexts:
+  - name: {{ include "oidc-webhook-authenticator.name" . }}
+    context:
+      cluster: {{ include "oidc-webhook-authenticator.name" . }}
+      user: {{ include "oidc-webhook-authenticator.name" . }}
+{{- end }}

--- a/charts/oidc-webhook-authenticator/charts/runtime/templates/deployment.yaml
+++ b/charts/oidc-webhook-authenticator/charts/runtime/templates/deployment.yaml
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "oidc-webhook-authenticator.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ include "oidc-webhook-authenticator.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: 5
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "oidc-webhook-authenticator.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      annotations:
+        checksum/secret-oidc-webhook-authenticator-tls: {{ include (print $.Template.BasePath "/secret-tls.yaml") . | sha256sum }}
+      labels:
+        app.kubernetes.io/name: {{ include "oidc-webhook-authenticator.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      serviceAccountName: {{ include "oidc-webhook-authenticator.name" . }}
+      containers:
+      - name: {{ include "oidc-webhook-authenticator.name" . }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        args:
+        - --tls-cert-file=/var/run/oidc-webhook-authenticator/tls/tls.crt
+        - --tls-private-key-file=/var/run/oidc-webhook-authenticator/tls/tls.key
+        {{- if .Values.kubeconfig }}
+        - --kubeconfig=/var/run/oidc-webhook-authenticator/kubeconfig/kubeconfig
+        {{- end }}
+        - --v=2
+        {{- if .Values.authKubeconfig }}
+        - --authentication-kubeconfig=/var/run/oidc-webhook-authenticator/auth-kubeconfig/kubeconfig
+        - --authorization-kubeconfig=/var/run/oidc-webhook-authenticator/auth-kubeconfig/kubeconfig
+        {{- else }}
+        - --authorization-always-allow-paths=/validate-token
+        - --authentication-skip-lookup=true
+        {{- end }}
+        resources:
+          {{- toYaml .Values.resources | nindent 10 }}
+        volumeMounts:
+        - name: tls
+          mountPath: /var/run/oidc-webhook-authenticator/tls
+          readOnly: true
+        {{- if .Values.kubeconfig }}
+        - name: kubeconfig
+          mountPath: /var/run/oidc-webhook-authenticator/kubeconfig
+          readOnly: true
+        {{- end }}
+        {{- if .Values.authKubeconfig }}
+        - name: auth-kubeconfig
+          mountPath: /var/run/oidc-webhook-authenticator/auth-kubeconfig
+          readOnly: true
+        {{- end }}
+      volumes:
+      - name: tls
+        secret:
+          secretName: oidc-webhook-authenticator-tls
+          defaultMode: 420
+      {{- if .Values.kubeconfig }}
+      - name: kubeconfig
+        secret:
+          secretName: oidc-webhook-authenticator-kubeconfig
+          defaultMode: 420
+      {{- end }}
+      {{- if .Values.authKubeconfig }}
+      - name: auth-kubeconfig
+        secret:
+          secretName: oidc-webhook-authenticator-auth-kubeconfig
+          defaultMode: 420
+      {{- end }}

--- a/charts/oidc-webhook-authenticator/charts/runtime/templates/rbac.yaml
+++ b/charts/oidc-webhook-authenticator/charts/runtime/templates/rbac.yaml
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "oidc-webhook-authenticator.name" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "oidc-webhook-authenticator.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: "system:auth-delegator"
+subjects:
+- apiGroup: ""
+  kind: ServiceAccount
+  name: {{ include "oidc-webhook-authenticator.name" . }}
+  namespace: {{ .Release.Namespace }}

--- a/charts/oidc-webhook-authenticator/charts/runtime/templates/secret-auth-kubeconfig.yaml
+++ b/charts/oidc-webhook-authenticator/charts/runtime/templates/secret-auth-kubeconfig.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.authKubeconfig }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: oidc-webhook-authenticator-auth-kubeconfig
+  namespace: "{{ .Release.Namespace }}"
+  labels:
+    app.kubernetes.io/name: {{ include "oidc-webhook-authenticator.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+type: Opaque
+data:
+  kubeconfig: {{ .Values.authKubeconfig | b64enc }}
+{{- end }}

--- a/charts/oidc-webhook-authenticator/charts/runtime/templates/secret-kubeconfig.yaml
+++ b/charts/oidc-webhook-authenticator/charts/runtime/templates/secret-kubeconfig.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.kubeconfig }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: oidc-webhook-authenticator-kubeconfig
+  namespace: "{{ .Release.Namespace }}"
+  labels:
+    app.kubernetes.io/name: {{ include "oidc-webhook-authenticator.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+type: Opaque
+data:
+  kubeconfig: {{ .Values.kubeconfig | b64enc }}
+{{- end }}

--- a/charts/oidc-webhook-authenticator/charts/runtime/templates/secret-tls.yaml
+++ b/charts/oidc-webhook-authenticator/charts/runtime/templates/secret-tls.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: oidc-webhook-authenticator-tls
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ include "oidc-webhook-authenticator.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+type: Opaque
+data:
+  tls.crt: {{ required ".Values.webhookConfig.tls.crt is required" (b64enc .Values.webhookConfig.tls.crt) }}
+  tls.key: {{ required ".Values.webhookConfig.tls.key is required" (b64enc .Values.webhookConfig.tls.key) }}

--- a/charts/oidc-webhook-authenticator/charts/runtime/templates/secret-webhook-kubeconfig.yaml
+++ b/charts/oidc-webhook-authenticator/charts/runtime/templates/secret-webhook-kubeconfig.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: oidc-webhook-authenticator-webhook-kubeconfig
+  namespace: "{{ .Release.Namespace }}"
+  labels:
+    app.kubernetes.io/name: {{ include "oidc-webhook-authenticator.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+type: Opaque
+data:
+  kubeconfig: {{ b64enc (include "oidc-webhook-authenticator.webhook-kubeconfig" .) }}

--- a/charts/oidc-webhook-authenticator/charts/runtime/templates/service.yaml
+++ b/charts/oidc-webhook-authenticator/charts/runtime/templates/service.yaml
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "oidc-webhook-authenticator.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ include "oidc-webhook-authenticator.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: {{ include "oidc-webhook-authenticator.name" . }}
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: 10443

--- a/charts/oidc-webhook-authenticator/charts/runtime/templates/serviceaccount.yaml
+++ b/charts/oidc-webhook-authenticator/charts/runtime/templates/serviceaccount.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "oidc-webhook-authenticator.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ include "oidc-webhook-authenticator.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}

--- a/charts/oidc-webhook-authenticator/charts/runtime/values.yaml
+++ b/charts/oidc-webhook-authenticator/charts/runtime/values.yaml
@@ -1,0 +1,1 @@
+../../values.yaml

--- a/charts/oidc-webhook-authenticator/templates/_helpers.tpl
+++ b/charts/oidc-webhook-authenticator/templates/_helpers.tpl
@@ -1,0 +1,27 @@
+{{- define "oidc-webhook-authenticator.name" -}}
+oidc-webhook-authenticator
+{{- end -}}
+
+{{-  define "oidc-webhook-authenticator.webhook-kubeconfig" -}}
+apiVersion: v1
+kind: Config
+clusters:
+  - name: {{ include "oidc-webhook-authenticator.name" . }}
+    cluster:
+{{- if .Values.virtualGarden.enabled }}
+      server: {{ printf "https://%s.%s/validate-token" (include "oidc-webhook-authenticator.name" .) (.Release.Namespace) }}
+{{- else }}
+      server: {{ printf "https://%s/validate-token" (include "oidc-webhook-authenticator.name" .) }}
+{{- end }}
+      certificate-authority-data: {{ required ".Values.webhookConfig.caBundle is required" (b64enc .Values.webhookConfig.caBundle) }}
+users:
+  - name: {{ include "oidc-webhook-authenticator.name" . }}
+    user:
+      tokenFile: /var/run/secrets/oidc-webhook-tokens/kube-apiserver-token
+current-context: {{ include "oidc-webhook-authenticator.name" . }}
+contexts:
+  - name: {{ include "oidc-webhook-authenticator.name" . }}
+    context:
+      cluster: {{ include "oidc-webhook-authenticator.name" . }}
+      user: {{ include "oidc-webhook-authenticator.name" . }}
+{{- end }}

--- a/charts/oidc-webhook-authenticator/values.yaml
+++ b/charts/oidc-webhook-authenticator/values.yaml
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+replicaCount: 2
+
+virtualGarden:
+  enabled: false
+
+image:
+  repository: eu.gcr.io/gardener-project/gardener/oidc-webhook-authenticator
+  tag: v0.1.0-dev-62b406c497468341cc0e5b81801444d0718ccd41
+  pullPolicy: IfNotPresent
+
+webhookConfig:
+  tls:
+      crt: |
+        -----BEGIN CERTIFICATE-----
+        ...
+        -----END CERTIFICATE-----
+      key: |
+        -----BEGIN RSA PRIVATE KEY-----
+        ...
+        -----END RSA PRIVATE KEY-----
+  caBundle: |
+      -----BEGIN CERTIFICATE-----
+      ...
+      -----END CERTIFICATE-----
+
+
+# Kubeconfig to the target cluster. In-cluster configuration will be used if not specified.
+kubeconfig: 
+
+authKubeconfig: 
+
+resources:
+  requests:
+   cpu: 100m
+   memory: 64Mi
+  limits:
+   cpu: 200m
+   memory: 256Mi


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the ability to easily install the OIDC webhook authenticator in two different clusters by dividing the chart installation to `runtime` and `application` parts.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
