### PR TITLE
Extension apiserver rolebinding moved to runtime cluster

### DIFF
--- a/charts/oidc-webhook-authenticator/charts/application/templates/rbac.yaml
+++ b/charts/oidc-webhook-authenticator/charts/application/templates/rbac.yaml
@@ -30,22 +30,6 @@ roleRef:
   kind: ClusterRole
   name: {{ include "oidc-webhook-authenticator.name" . }}
 subjects:
-- apiGroup: rbac.authorization.k8s.io
-  kind: User
+- kind: ServiceAccount
   name: {{ include "oidc-webhook-authenticator.name" . }}
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: {{ include "oidc-webhook-authenticator.name" . }}
-  namespace: kube-system
-  labels:
-    app.kubernetes.io/name: {{ include "oidc-webhook-authenticator.name" . }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: extension-apiserver-authentication-reader
-subjects:
-- apiGroup: rbac.authorization.k8s.io
-  kind: User
-  name: {{ include "oidc-webhook-authenticator.name" . }}
+  namespace: {{ .Release.Namespace }}

--- a/charts/oidc-webhook-authenticator/charts/application/templates/serviceaccount.yaml
+++ b/charts/oidc-webhook-authenticator/charts/application/templates/serviceaccount.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "oidc-webhook-authenticator.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ include "oidc-webhook-authenticator.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}

--- a/charts/oidc-webhook-authenticator/charts/runtime/templates/rbac.yaml
+++ b/charts/oidc-webhook-authenticator/charts/runtime/templates/rbac.yaml
@@ -16,7 +16,22 @@ roleRef:
   kind: ClusterRole
   name: "system:auth-delegator"
 subjects:
-- apiGroup: ""
-  kind: ServiceAccount
+- kind: ServiceAccount
+  name: {{ include "oidc-webhook-authenticator.name" . }}
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "oidc-webhook-authenticator.name" . }}
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: {{ include "oidc-webhook-authenticator.name" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+- kind: ServiceAccount
   name: {{ include "oidc-webhook-authenticator.name" . }}
   namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR moves the rolebinding for role `extension-apiserver-authentication-reader` into the runtime cluster where the authentication and authorization of the calling API server will be performed.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
