### PR TITLE
Fixed charts for single cluster installation

### DIFF
--- a/charts/oidc-webhook-authenticator/charts/application/templates/rbac.yaml
+++ b/charts/oidc-webhook-authenticator/charts/application/templates/rbac.yaml
@@ -6,7 +6,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "oidc-webhook-authenticator.name" . }}
+  name: {{ include "oidc-webhook-authenticator.name" . }}-resource-reader
   labels:
     app.kubernetes.io/name: {{ include "oidc-webhook-authenticator.name" . }}
 rules:
@@ -22,13 +22,13 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "oidc-webhook-authenticator.name" . }}
+  name: {{ include "oidc-webhook-authenticator.name" . }}-resource-reader-binding
   labels:
     app.kubernetes.io/name: {{ include "oidc-webhook-authenticator.name" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "oidc-webhook-authenticator.name" . }}
+  name: {{ include "oidc-webhook-authenticator.name" . }}-resource-reader
 subjects:
 - kind: ServiceAccount
   name: {{ include "oidc-webhook-authenticator.name" . }}

--- a/charts/oidc-webhook-authenticator/charts/application/templates/serviceaccount.yaml
+++ b/charts/oidc-webhook-authenticator/charts/application/templates/serviceaccount.yaml
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+{{- if .Values.virtualGarden.enabled }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -12,3 +13,4 @@ metadata:
     app.kubernetes.io/name: {{ include "oidc-webhook-authenticator.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}

--- a/charts/oidc-webhook-authenticator/charts/runtime/templates/rbac.yaml
+++ b/charts/oidc-webhook-authenticator/charts/runtime/templates/rbac.yaml
@@ -6,7 +6,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "oidc-webhook-authenticator.name" . }}
+  name: {{ include "oidc-webhook-authenticator.name" . }}-auth-delegator-binding
   labels:
     app.kubernetes.io/name: {{ include "oidc-webhook-authenticator.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
@@ -23,7 +23,7 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ include "oidc-webhook-authenticator.name" . }}
+  name: {{ include "oidc-webhook-authenticator.name" . }}-extension-apiserver-binding
   namespace: kube-system
   labels:
     app.kubernetes.io/name: {{ include "oidc-webhook-authenticator.name" . }}

--- a/charts/oidc-webhook-authenticator/charts/runtime/templates/service.yaml
+++ b/charts/oidc-webhook-authenticator/charts/runtime/templates/service.yaml
@@ -17,6 +17,7 @@ spec:
   selector:
     app.kubernetes.io/name: {{ include "oidc-webhook-authenticator.name" . }}
   ports:
-  - port: 443
+  - name: https
+    port: 443
     protocol: TCP
     targetPort: 10443

--- a/charts/oidc-webhook-authenticator/values.yaml
+++ b/charts/oidc-webhook-authenticator/values.yaml
@@ -2,11 +2,14 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-replicaCount: 2
+virtualGarden:
+  enabled: false
+
+replicaCount: 1
 
 image:
   repository: eu.gcr.io/gardener-project/gardener/oidc-webhook-authenticator
-  tag: v0.1.0-dev-62b406c497468341cc0e5b81801444d0718ccd41
+  tag: v0.1.0
   pullPolicy: IfNotPresent
 
 webhookConfig:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR:
* Fixes a bug when installing the whole set of charts into a single cluster. The installation was failing due to duplicate `serviceaccounts` and `clusterrolebindings`.
* Sets the default install version to `v0.1.0`.
* Sets the default replica count to 1.
* Gives a name to the service port so that it can be easily selected.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fixed a bug where single cluster installation of the authenticator was failing due to duplicate `serviceaccounts` and `clusterrolebindings` in the helm chart definitions.
```
