### PR TITLE
Adds the ability to install the webhook with automatically rotating service account tokens

### DIFF
--- a/charts/oidc-webhook-authenticator/charts/runtime/templates/deployment.yaml
+++ b/charts/oidc-webhook-authenticator/charts/runtime/templates/deployment.yaml
@@ -33,6 +33,9 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
       serviceAccountName: {{ include "oidc-webhook-authenticator.name" . }}
+      {{- if .Values.serviceAccountTokenVolumeProjection.enabled }}
+      automountServiceAccountToken: false
+      {{- end }}
       containers:
       - name: {{ include "oidc-webhook-authenticator.name" . }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -40,7 +43,7 @@ spec:
         args:
         - --tls-cert-file=/var/run/oidc-webhook-authenticator/tls/tls.crt
         - --tls-private-key-file=/var/run/oidc-webhook-authenticator/tls/tls.key
-        {{- if .Values.kubeconfig }}
+        {{- if or .Values.serviceAccountTokenVolumeProjection.enabled .Values.kubeconfig }}
         - --kubeconfig=/var/run/oidc-webhook-authenticator/kubeconfig/kubeconfig
         {{- end }}
         - --v=2
@@ -75,6 +78,11 @@ spec:
           mountPath: /var/run/oidc-webhook-authenticator/auth-kubeconfig
           readOnly: true
         {{- end }}
+        {{- if .Values.serviceAccountTokenVolumeProjection.enabled }}
+        - name: service-account-token
+          mountPath: /var/run/oidc-webhook-authenticator/serviceaccount
+          readOnly: true
+        {{- end }}
       volumes:
       - name: tls
         secret:
@@ -91,4 +99,19 @@ spec:
         secret:
           secretName: oidc-webhook-authenticator-auth-kubeconfig
           defaultMode: 420
+      {{- end }}
+      {{- if .Values.serviceAccountTokenVolumeProjection.enabled }}
+      - name: service-account-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              path: token
+              {{- if .Values.serviceAccountTokenVolumeProjection.expirationSeconds }}
+              expirationSeconds: {{ .Values.serviceAccountTokenVolumeProjection.expirationSeconds }}
+              {{- else }}
+              expirationSeconds: 1800
+              {{- end }}
+              {{- if .Values.serviceAccountTokenVolumeProjection.audience }}
+              audience: {{ .Values.serviceAccountTokenVolumeProjection.audience }}
+              {{- end }}
       {{- end }}

--- a/charts/oidc-webhook-authenticator/charts/runtime/templates/secret-kubeconfig.yaml
+++ b/charts/oidc-webhook-authenticator/charts/runtime/templates/secret-kubeconfig.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-{{- if .Values.kubeconfig }}
+{{- if or .Values.serviceAccountTokenVolumeProjection.enabled .Values.kubeconfig }}
 ---
 apiVersion: v1
 kind: Secret
@@ -15,5 +15,5 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 type: Opaque
 data:
-  kubeconfig: {{ .Values.kubeconfig | b64enc }}
+  kubeconfig: {{ required ".Values.kubeconfig is required" .Values.kubeconfig | b64enc }}
 {{- end }}

--- a/charts/oidc-webhook-authenticator/values.yaml
+++ b/charts/oidc-webhook-authenticator/values.yaml
@@ -24,6 +24,7 @@ webhookConfig:
         -----END RSA PRIVATE KEY-----
 
 # Kubeconfig to the target cluster. In-cluster configuration will be used if not specified.
+# If serviceAccountTokenVolumeProjection.enabled is set to `true` then this value is required.
 kubeconfig: 
 
 authKubeconfig: 
@@ -35,3 +36,8 @@ resources:
   limits:
    cpu: 200m
    memory: 256Mi
+
+serviceAccountTokenVolumeProjection:
+  enabled: false
+  expirationSeconds: 1800
+  audience: ""


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the ability to install the `oidc-webhook-authenticator` with automatically rotating service account tokens mounted via `projected volume source`. Note that the automount of the static service account token will be disabled if this feature is enabled.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
It is now possible to mount the service account token of the `oidc-webhook-authenticator` via projected volume source by setting `.serviceAccountTokenVolumeProjection.enabled: true` in the values.yaml file. This will ensure the automatic rotation of the token by the `kubelet`. Note that if this feature is enabled then the static service account token will no longer be mounted on the well known path `/var/run/secrets/kubernetes.io/serviceaccount/token` in the pod's filesystem and the `.kubeconfig` field in the values.yaml file will become required.
```
