### PR TITLE
Split rbac rules and add condition for installation

### DIFF
--- a/charts/oidc-webhook-authenticator/charts/runtime/templates/role-binding-auth-delegator.yaml
+++ b/charts/oidc-webhook-authenticator/charts/runtime/templates/role-binding-auth-delegator.yaml
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+{{- if .Values.authKubeconfig }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -19,19 +20,4 @@ subjects:
 - kind: ServiceAccount
   name: {{ include "oidc-webhook-authenticator.name" . }}
   namespace: {{ .Release.Namespace }}
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: {{ include "oidc-webhook-authenticator.name" . }}-extension-apiserver-binding
-  namespace: kube-system
-  labels:
-    app.kubernetes.io/name: {{ include "oidc-webhook-authenticator.name" . }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: extension-apiserver-authentication-reader
-subjects:
-- kind: ServiceAccount
-  name: {{ include "oidc-webhook-authenticator.name" . }}
-  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/oidc-webhook-authenticator/charts/runtime/templates/role-binding-extension-apiserver.yaml
+++ b/charts/oidc-webhook-authenticator/charts/runtime/templates/role-binding-extension-apiserver.yaml
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.authKubeconfig }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "oidc-webhook-authenticator.name" . }}-extension-apiserver-binding
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: {{ include "oidc-webhook-authenticator.name" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+- kind: ServiceAccount
+  name: {{ include "oidc-webhook-authenticator.name" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR splits rbac rules and installs them only if `authKubeconfig` is specified in the `values.yaml` file.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
