### PR TITLE
Adds the ability to configure api audiences flag

### DIFF
--- a/charts/oidc-webhook-authenticator/charts/runtime/templates/deployment.yaml
+++ b/charts/oidc-webhook-authenticator/charts/runtime/templates/deployment.yaml
@@ -54,6 +54,9 @@ spec:
         - --authorization-always-allow-paths=/validate-token
         - --authentication-skip-lookup=true
         {{- end }}
+        {{- if .Values.apiAudiences }}
+        - --api-audiences={{ .Values.apiAudiences | join "," }}
+        {{- end }}
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/charts/oidc-webhook-authenticator/values.yaml
+++ b/charts/oidc-webhook-authenticator/values.yaml
@@ -41,3 +41,6 @@ serviceAccountTokenVolumeProjection:
   enabled: false
   expirationSeconds: 1800
   audience: ""
+
+# List with identifiers of the API. Tokens used against the API should be bound to at least one of these audiences.
+apiAudiences: []

--- a/cmd/oidc-webhook-authenticator/app/oidc_webhook_authenticator.go
+++ b/cmd/oidc-webhook-authenticator/app/oidc_webhook_authenticator.go
@@ -75,12 +75,12 @@ func NewOIDCWebhookAuthenticatorCommand(ctx context.Context) *cobra.Command {
 
 	fs := cmd.Flags()
 	verflag.AddFlags(fs)
+	fs.StringSliceVar((*[]string)(&conf.Authentication.APIAudiences), "api-audiences", []string{}, "Identifiers of the API. Tokens used against the API should be bound to at least one of these audiences.")
+
 	opt.AddFlags(fs)
 	globalflag.AddGlobalFlags(fs, "global")
 
-	opts := zap.Options{
-		Development: true,
-	}
+	opts := zap.Options{}
 	opts.BindFlags(goflag.CommandLine)
 	fs.AddGoFlagSet(goflag.CommandLine)
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the ability to configure `--api-audiences` flag. This will ensure that tokens used against the authenticator are bound to at least one of the audiences specified in the flag value.
**Which issue(s) this PR fixes**:
Fixes #30 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
It is now possible to ensure that tokens used against the authenticator are bound to at least one of the specified audiences by setting `--api-audiences=value1,value2`
```
