### PR TITLE
Fix the initialization of defaulting and validating webhooks

### DIFF
--- a/charts/oidc-webhook-authenticator/charts/application/templates/validating-webhook-configuration.yaml
+++ b/charts/oidc-webhook-authenticator/charts/application/templates/validating-webhook-configuration.yaml
@@ -1,0 +1,33 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: {{ include "oidc-webhook-authenticator.name" . }}
+webhooks:
+- name: validation.oidc.webhook.authenticator
+  rules:
+  - apiGroups:
+    - "authentication.gardener.cloud"
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - openidconnects
+  failurePolicy: Fail
+  objectSelector: {}
+  namespaceSelector: {}
+  sideEffects: None
+  admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    {{- if .Values.virtualGarden.enabled }}
+    url: {{ printf "https://%s.%s/webhooks/validating" (include "oidc-webhook-authenticator.name" .) (.Release.Namespace) }}
+    {{- else }}
+    service:
+      namespace: {{ .Release.Namespace }}
+      name: {{ include "oidc-webhook-authenticator.name" . }}
+      path: /webhooks/validating
+    {{- end }}
+    caBundle: {{ required ".Values.webhookConfig.caBundle is required" (b64enc .Values.webhookConfig.caBundle) }}

--- a/charts/oidc-webhook-authenticator/values.yaml
+++ b/charts/oidc-webhook-authenticator/values.yaml
@@ -22,6 +22,10 @@ webhookConfig:
         -----BEGIN RSA PRIVATE KEY-----
         ...
         -----END RSA PRIVATE KEY-----
+  caBundle: |
+    -----BEGIN CERTIFICATE-----
+    ...
+    -----END CERTIFICATE-----
 
 # Kubeconfig to the target cluster. In-cluster configuration will be used if not specified.
 # If automountServiceAccountToken is set to `true` then this value is required because in-cluster configuration will not work.
@@ -37,6 +41,7 @@ auth:
   # A list of HTTP paths to skip during authorization.
   authorizationAlwaysAllowPaths:
   - /healthz
+  - /webhooks/validating
 
 resources:
   requests:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR sets logger to defaulting and validating webhooks. It also adds a validating webhook for the `openidconnect` resources to the `helm` chart installation.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
It is now required to provide `.webhookConfig.caBundle` in the `values.yaml` file when installing via `helm` in order to successfully register a validating webhook for the `openidconnect` resources.
```

```feature user
`validatingwebhookconfiguration` for the `openidconnect` resources is now installed with the `helm` chart.
```
