### PR TITLE
Extend chart installation configuration

### DIFF
--- a/charts/oidc-webhook-authenticator/charts/runtime/templates/deployment.yaml
+++ b/charts/oidc-webhook-authenticator/charts/runtime/templates/deployment.yaml
@@ -33,8 +33,8 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
       serviceAccountName: {{ include "oidc-webhook-authenticator.name" . }}
-      {{- if .Values.serviceAccountTokenVolumeProjection.enabled }}
-      automountServiceAccountToken: false
+      {{- if .Values.automountServiceAccountToken }}
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
       {{- end }}
       containers:
       - name: {{ include "oidc-webhook-authenticator.name" . }}
@@ -43,20 +43,18 @@ spec:
         args:
         - --tls-cert-file=/var/run/oidc-webhook-authenticator/tls/tls.crt
         - --tls-private-key-file=/var/run/oidc-webhook-authenticator/tls/tls.key
-        {{- if or .Values.serviceAccountTokenVolumeProjection.enabled .Values.kubeconfig }}
+        {{- if .Values.kubeconfig }}
         - --kubeconfig=/var/run/oidc-webhook-authenticator/kubeconfig/kubeconfig
         {{- end }}
         - --v=2
-        {{- if .Values.authKubeconfig }}
+        {{- if .Values.auth.kubeconfig }}
         - --authentication-kubeconfig=/var/run/oidc-webhook-authenticator/auth-kubeconfig/kubeconfig
         - --authorization-kubeconfig=/var/run/oidc-webhook-authenticator/auth-kubeconfig/kubeconfig
-        {{- else }}
-        - --authorization-always-allow-paths=/validate-token
-        - --authentication-skip-lookup=true
         {{- end }}
         {{- if .Values.apiAudiences }}
         - --api-audiences={{ .Values.apiAudiences | join "," }}
         {{- end }}
+        - --authorization-always-allow-paths={{ .Values.auth.authorizationAlwaysAllowPaths | join "," }}
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -76,7 +74,7 @@ spec:
           mountPath: /var/run/oidc-webhook-authenticator/kubeconfig
           readOnly: true
         {{- end }}
-        {{- if .Values.authKubeconfig }}
+        {{- if .Values.auth.kubeconfig }}
         - name: auth-kubeconfig
           mountPath: /var/run/oidc-webhook-authenticator/auth-kubeconfig
           readOnly: true
@@ -97,7 +95,7 @@ spec:
           secretName: oidc-webhook-authenticator-kubeconfig
           defaultMode: 420
       {{- end }}
-      {{- if .Values.authKubeconfig }}
+      {{- if .Values.auth.kubeconfig }}
       - name: auth-kubeconfig
         secret:
           secretName: oidc-webhook-authenticator-auth-kubeconfig

--- a/charts/oidc-webhook-authenticator/charts/runtime/templates/role-binding-auth-delegator.yaml
+++ b/charts/oidc-webhook-authenticator/charts/runtime/templates/role-binding-auth-delegator.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-{{- if .Values.authKubeconfig }}
+{{- if .Values.auth.installDelegatorBindings }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/charts/oidc-webhook-authenticator/charts/runtime/templates/role-binding-extension-apiserver.yaml
+++ b/charts/oidc-webhook-authenticator/charts/runtime/templates/role-binding-extension-apiserver.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-{{- if .Values.authKubeconfig }}
+{{- if .Values.auth.installDelegatorBindings }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/charts/oidc-webhook-authenticator/charts/runtime/templates/secret-auth-kubeconfig.yaml
+++ b/charts/oidc-webhook-authenticator/charts/runtime/templates/secret-auth-kubeconfig.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-{{- if .Values.authKubeconfig }}
+{{- if or ( not .Values.automountServiceAccountToken ) .Values.auth.kubeconfig }}
 ---
 apiVersion: v1
 kind: Secret
@@ -15,5 +15,5 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 type: Opaque
 data:
-  kubeconfig: {{ .Values.authKubeconfig | b64enc }}
+  kubeconfig: {{ required ".Values.auth.kubeconfig is required" .Values.auth.kubeconfig | b64enc }}
 {{- end }}

--- a/charts/oidc-webhook-authenticator/charts/runtime/templates/secret-kubeconfig.yaml
+++ b/charts/oidc-webhook-authenticator/charts/runtime/templates/secret-kubeconfig.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-{{- if or .Values.serviceAccountTokenVolumeProjection.enabled .Values.kubeconfig }}
+{{- if or ( not .Values.automountServiceAccountToken ) .Values.kubeconfig }}
 ---
 apiVersion: v1
 kind: Secret

--- a/charts/oidc-webhook-authenticator/values.yaml
+++ b/charts/oidc-webhook-authenticator/values.yaml
@@ -9,7 +9,7 @@ replicaCount: 1
 
 image:
   repository: eu.gcr.io/gardener-project/gardener/oidc-webhook-authenticator
-  tag: v0.1.0
+  tag: latest
   pullPolicy: IfNotPresent
 
 webhookConfig:
@@ -24,10 +24,19 @@ webhookConfig:
         -----END RSA PRIVATE KEY-----
 
 # Kubeconfig to the target cluster. In-cluster configuration will be used if not specified.
-# If serviceAccountTokenVolumeProjection.enabled is set to `true` then this value is required.
+# If automountServiceAccountToken is set to `true` then this value is required because in-cluster configuration will not work.
 kubeconfig: 
 
-authKubeconfig: 
+auth:
+  # Kubeconfig to the target authentication and authorization cluster. In-cluster configuration will be used if not specified.
+  # If automountServiceAccountToken is set to `true` then this value is required because in-cluster configuration will not work.
+  kubeconfig:
+  # Specifies if rolebinding to role extension-apiserver-authentication-reader in kube-system namespace and clusterrolebinding to cluster role system:auth-delegator
+  # should be created for the webhook's service account. Usually there is no need for this value to be `false`.
+  installDelegatorBindings: true
+  # A list of HTTP paths to skip during authorization.
+  authorizationAlwaysAllowPaths:
+  - /healthz
 
 resources:
   requests:
@@ -36,6 +45,8 @@ resources:
   limits:
    cpu: 200m
    memory: 256Mi
+
+automountServiceAccountToken: true
 
 serviceAccountTokenVolumeProjection:
   enabled: false


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR extends the chart configurations and provides a more user friendly defaults.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking user
In values.yaml file .authKubeconfig is now replaced with `.auth.kubeconfig`
```

```feature user
It is now possible to specify http paths that will not require authorization by setting `.auth.authorizationAlwaysAllowPaths` in the values.yaml file.
```

```feature user
It is now possible to explicitly specify if the service account token for the `oidc-webhook-authenticator` pod should be automounted by setting `.automountServiceAccountToken` in the values.yaml file.
```

```feature user
It is now possible to explicitly skip the installation of auth-delegator RBACs by setting `auth.installDelegatorBindings: false` in the values.yaml file. This is useful when the auth cluster is different from where the `oidc-webhook-authenticator` is installed.
```