### PR TITLE
Add validation for malicious prefixes

### DIFF
--- a/apis/authentication/v1alpha1/openidconnect_types.go
+++ b/apis/authentication/v1alpha1/openidconnect_types.go
@@ -164,9 +164,14 @@ const (
 	PS512 SigningAlgorithm = "PS512"
 )
 
-// ClaimPrefixingDisabled indicates that username or groups claim should not be
-// prefixed automatically.
-const ClaimPrefixingDisabled = "-"
+const (
+	// ClaimPrefixingDisabled indicates that username or groups claim should not be
+	// prefixed automatically.
+	ClaimPrefixingDisabled = "-"
+
+	// SystemPrefix is a forbidden prefix. Usernames and groups starting with this value will be ignored.
+	SystemPrefix = "system:"
+)
 
 type OIDCAuthenticationStatus struct{}
 

--- a/controllers/authentication/openidconnect_controller.go
+++ b/controllers/authentication/openidconnect_controller.go
@@ -249,7 +249,7 @@ func (u *unionAuthTokenHandler) AuthenticateToken(ctx context.Context, token str
 		if done {
 			userName := resp.User.GetName()
 			// Mark token as invalid when userName has "system:" prefix.
-			if strings.HasPrefix(userName, "system:") {
+			if strings.HasPrefix(userName, authenticationv1alpha1.SystemPrefix) {
 				// TODO add logging
 
 				return false
@@ -258,7 +258,7 @@ func (u *unionAuthTokenHandler) AuthenticateToken(ctx context.Context, token str
 			filteredGroups := []string{}
 			for _, group := range resp.User.GetGroups() {
 				// ignore groups with "system:" prefix
-				if !strings.HasPrefix(group, "system:") {
+				if !strings.HasPrefix(group, authenticationv1alpha1.SystemPrefix) {
 					filteredGroups = append(filteredGroups, group)
 				}
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR introduces username and groups prefix validation when a validating webhook is registered for the `openidconnect` resources.

**Which issue(s) this PR fixes**:
Fixes #44 

**Special notes for your reviewer**:
In order to execute the tests run `make test`.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Username and groups prefixes starting with `system:` will be rejected if a validating webhook is registered for the `openidconnect` resources.
```
