### PR TITLE
Configure slack notifications on release

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -42,6 +42,12 @@ oidc-webhook-authenticator:
           preprocess: finalize
         release:
           nextversion: bump_minor
+        slack:
+          default_channel: 'internal_scp_workspace'
+          channel_cfgs:
+            internal_scp_workspace:
+              channel_name: 'C9CEBQPGE' #sap-tech-gardener
+              slack_cfg_name: 'scp_workspace'
         component_descriptor: ~
         publish:
           dockerimages:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR configures notifications to `sap-tech-gardener` slack channel when a new version of the `oidc-webhook-authenticator` is released.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
