### PR TITLE
Adds the ability to configure hpa

### DIFF
--- a/charts/oidc-webhook-authenticator/charts/runtime/templates/deployment.yaml
+++ b/charts/oidc-webhook-authenticator/charts/runtime/templates/deployment.yaml
@@ -19,7 +19,7 @@ spec:
     type: RollingUpdate
     rollingUpdate:
       maxSurge: 1
-      maxUnavailable: 1
+      maxUnavailable: 0
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "oidc-webhook-authenticator.name" . }}

--- a/charts/oidc-webhook-authenticator/charts/runtime/templates/hpa.yaml
+++ b/charts/oidc-webhook-authenticator/charts/runtime/templates/hpa.yaml
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.autoscaling.hpa.enabled }}
+---
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "oidc-webhook-authenticator.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ include "oidc-webhook-authenticator.name" . }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "oidc-webhook-authenticator.name" . }}
+  minReplicas: {{ .Values.autoscaling.hpa.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.hpa.maxReplicas }}
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      targetAverageUtilization: {{ .Values.autoscaling.hpa.cpuTargetAverageUtilization }}
+{{- end }}

--- a/charts/oidc-webhook-authenticator/values.yaml
+++ b/charts/oidc-webhook-authenticator/values.yaml
@@ -12,6 +12,13 @@ image:
   tag: latest
   pullPolicy: IfNotPresent
 
+autoscaling:
+  hpa:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 3
+    cpuTargetAverageUtilization: 80
+
 webhookConfig:
   tls:
       crt: |


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the ability to configure `horizontal pod autoscaler` for the `oidc-webhook-authenticator`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
It is now possible to configure Horizontal Pod Autoscaler by setting `.values.autoscaling.hpa.enabled: true`.
```
