### PR TITLE
Remove apt-get update when tests are executed by the CI/CD

### DIFF
--- a/.ci/test
+++ b/.ci/test
@@ -17,8 +17,6 @@ fi
 
 cd "${SOURCE_PATH}"
 
-apt-get update
-
 go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
 
 make test


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove apt-get update when tests are executed by the CI/CD

As no packages are installed, it is not necessary to update the registry cache.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
