### PR TITLE
Adds the ability to configure user for the virtual garden bindings

### DIFF
--- a/charts/oidc-webhook-authenticator/charts/application/templates/rbac.yaml
+++ b/charts/oidc-webhook-authenticator/charts/application/templates/rbac.yaml
@@ -30,6 +30,12 @@ roleRef:
   kind: ClusterRole
   name: {{ include "oidc-webhook-authenticator.name" . }}-resource-reader
 subjects:
+{{- if and .Values.virtualGarden.enabled .Values.virtualGarden.user.name  }}
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: {{ .Values.virtualGarden.user.name  }}
+{{- else }}
 - kind: ServiceAccount
   name: {{ include "oidc-webhook-authenticator.name" . }}
   namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/oidc-webhook-authenticator/charts/application/templates/role-binding-auth-delegator.yaml
+++ b/charts/oidc-webhook-authenticator/charts/application/templates/role-binding-auth-delegator.yaml
@@ -17,7 +17,13 @@ roleRef:
   kind: ClusterRole
   name: "system:auth-delegator"
 subjects:
+{{- if and .Values.virtualGarden.enabled .Values.virtualGarden.user.name  }}
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: {{ .Values.virtualGarden.user.name  }}
+{{- else }}
 - kind: ServiceAccount
   name: {{ include "oidc-webhook-authenticator.name" . }}
   namespace: {{ .Release.Namespace }}
+{{- end }}
 {{- end }}

--- a/charts/oidc-webhook-authenticator/charts/application/templates/role-binding-extension-apiserver.yaml
+++ b/charts/oidc-webhook-authenticator/charts/application/templates/role-binding-extension-apiserver.yaml
@@ -16,7 +16,13 @@ roleRef:
   kind: Role
   name: extension-apiserver-authentication-reader
 subjects:
+{{- if and .Values.virtualGarden.enabled .Values.virtualGarden.user.name  }}
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: {{ .Values.virtualGarden.user.name  }}
+{{- else }}
 - kind: ServiceAccount
   name: {{ include "oidc-webhook-authenticator.name" . }}
   namespace: {{ .Release.Namespace }}
+{{- end }}
 {{- end }}

--- a/charts/oidc-webhook-authenticator/charts/application/templates/serviceaccount.yaml
+++ b/charts/oidc-webhook-authenticator/charts/application/templates/serviceaccount.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-{{- if .Values.virtualGarden.enabled }}
+{{- if and .Values.virtualGarden.enabled ( not .Values.virtualGarden.user.name ) }}
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/charts/oidc-webhook-authenticator/values.yaml
+++ b/charts/oidc-webhook-authenticator/values.yaml
@@ -4,6 +4,8 @@
 
 virtualGarden:
   enabled: false
+  user:
+    name: ""
 
 replicaCount: 1
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the ability to configure a `User` (instead of a `ServiceAccount`) to be bound to the `oidc-webhook-authenticator`'s roles when the installation is performed in a multi-cluster environment (e.g., virtual garden is enabled).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
I am not quite happy with the configuration `.user.name` so I am open to other name/setup suggestions.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
It is now possible to configure a `User` (instead of a `ServiceAccount`) to be bound to the needed roles in the target cluster by setting `.virtualGarden.user.name`. 
```
