### PR TITLE
Fix helm lint

### DIFF
--- a/charts/oidc-webhook-authenticator/Chart.yaml
+++ b/charts/oidc-webhook-authenticator/Chart.yaml
@@ -2,8 +2,15 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-apiVersion: v1
+apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for Kubernetes the OpenID Connect Webhook Authenticator. It allows Kubernetes cluster administrators to dynamically register new OpenID Connect providers in their clusters to use for kube-apiserver authentication.
 name: oidc-webhook-authenticator
 version: 0.1.0
+dependencies:
+  - name: application
+    repository: http://localhost:10191
+    version: 0.1.0
+  - name: runtime
+    repository: http://localhost:10191
+    version: 0.1.0

--- a/charts/oidc-webhook-authenticator/charts/application/Chart.yaml
+++ b/charts/oidc-webhook-authenticator/charts/application/Chart.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-apiVersion: v1
+apiVersion: v2
 description: A Helm chart to deploy the oidc-webhook-authenticator application related resources
 name: application
 version: 0.1.0

--- a/charts/oidc-webhook-authenticator/charts/runtime/Chart.yaml
+++ b/charts/oidc-webhook-authenticator/charts/runtime/Chart.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-apiVersion: v1
+apiVersion: v2
 description: A Helm chart to deploy the oidc-webhook-authenticator runtime related resources
 name: runtime
 version: 0.1.0


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix helm lint which is currently failing with
```bash
[ERROR] /home/vpnachev/go/src/github.com/gardener/oidc-webhook-authenticator/charts/oidc-webhook-authenticator: chart metadata is missing these dependencies: application,runtime

Error: 1 chart(s) linted, 1 chart(s) failed
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
