### PR TITLE
Stop defaulting username and groups claims

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ help: ## Display this help.
 ##@ Development
 
 manifests: tools-image ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
-	docker run --rm --name=oidc-tools -v $(shell pwd):/workspace tools:latest controller-gen $(CRD_OPTIONS) rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+	docker run --rm --name=oidc-tools -v $(shell pwd):/workspace tools:latest controller-gen rbac:roleName=manager-role webhook paths="./..." crd paths=./apis/... output:crd:artifacts:config=config/crd/bases
 	cat hack/license_boilerplate.yaml.txt > charts/oidc-webhook-authenticator/charts/application/templates/authentication.gardener.cloud_openidconnects.yaml
 	cat config/crd/bases/authentication.gardener.cloud_openidconnects.yaml >> charts/oidc-webhook-authenticator/charts/application/templates/authentication.gardener.cloud_openidconnects.yaml
 

--- a/apis/authentication/v1alpha1/openidconnect_types.go
+++ b/apis/authentication/v1alpha1/openidconnect_types.go
@@ -64,11 +64,11 @@ type OIDCAuthenticationSpec struct {
 	// See: https://openid.net/specs/openid-connect-core-1_0.html#IDToken
 	ClientID string `json:"clientID"`
 
-	// +optional
-	// +kubebuilder:default=sub
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:MinLength=1
 
 	// UsernameClaim is the JWT field to use as the user's username.
-	UsernameClaim *string `json:"usernameClaim,omitempty"`
+	UsernameClaim *string `json:"usernameClaim"`
 
 	// +optional
 
@@ -76,11 +76,10 @@ type OIDCAuthenticationSpec struct {
 	// the provided value. A value "oidc:" would result in usernames like "oidc:john".
 	//
 	// If not provided, the prefix defaults to "( .metadata.name )/".
-	// The value "-"" can be used to disable all prefixing.
+	// The value "-" can be used to disable all prefixing.
 	UsernamePrefix *string `json:"usernamePrefix,omitempty"`
 
 	// +optional
-	// +kubebuilder:default=groups
 
 	// GroupsClaim, if specified, causes the OIDCAuthenticator to try to populate the user's
 	// groups with an ID Token field. If the GroupsClaim field is present in an ID Token the value
@@ -93,7 +92,7 @@ type OIDCAuthenticationSpec struct {
 	// value. A value "oidc:" would result in groups like "oidc:engineering" and "oidc:marketing".
 	//
 	// If not provided, the prefix defaults to "( .metadata.name )/".
-	// The value "-"" can be used to disable all prefixing.
+	// The value "-" can be used to disable all prefixing.
 	GroupsPrefix *string `json:"groupsPrefix,omitempty"`
 
 	// +kubebuilder:default={RS256}
@@ -118,7 +117,7 @@ type OIDCAuthenticationSpec struct {
 	// +optional
 
 	// CABundle is a PEM encoded CA bundle which will be used to validate the OpenID server's certificate.
-	// If unspecified, system trust roots on the apiserver are used.
+	// If unspecified, system's trusted certificates are used.
 	CABundle []byte `json:"caBundle,omitempty"`
 
 	// +optional

--- a/charts/oidc-webhook-authenticator/charts/application/templates/authentication.gardener.cloud_openidconnects.yaml
+++ b/charts/oidc-webhook-authenticator/charts/application/templates/authentication.gardener.cloud_openidconnects.yaml
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   name: openidconnects.authentication.gardener.cloud
 spec:
@@ -66,8 +67,8 @@ spec:
             properties:
               caBundle:
                 description: CABundle is a PEM encoded CA bundle which will be used
-                  to validate the OpenID server's certificate. If unspecified, system
-                  trust roots on the apiserver are used.
+                  to validate the OpenID server's certificate. If unspecified, system's
+                  trusted certificates are used.
                 format: byte
                 type: string
               clientID:
@@ -78,7 +79,6 @@ spec:
                 minLength: 1
                 type: string
               groupsClaim:
-                default: groups
                 description: GroupsClaim, if specified, causes the OIDCAuthenticator
                   to try to populate the user's groups with an ID Token field. If
                   the GroupsClaim field is present in an ID Token the value must be
@@ -89,7 +89,7 @@ spec:
                   group names to be prefixed with the value. A value \"oidc:\" would
                   result in groups like \"oidc:engineering\" and \"oidc:marketing\".
                   \n If not provided, the prefix defaults to \"( .metadata.name )/\".
-                  The value \"-\"\" can be used to disable all prefixing."
+                  The value \"-\" can be used to disable all prefixing."
                 type: string
               issuerURL:
                 description: "IssuerURL is the URL the provider signs ID Tokens as.
@@ -147,19 +147,20 @@ spec:
                   type: string
                 type: array
               usernameClaim:
-                default: sub
                 description: UsernameClaim is the JWT field to use as the user's username.
+                minLength: 1
                 type: string
               usernamePrefix:
                 description: "UsernamePrefix, if specified, causes claims mapping
                   to username to be prefix with the provided value. A value \"oidc:\"
                   would result in usernames like \"oidc:john\". \n If not provided,
-                  the prefix defaults to \"( .metadata.name )/\". The value \"-\"\"
+                  the prefix defaults to \"( .metadata.name )/\". The value \"-\"
                   can be used to disable all prefixing."
                 type: string
             required:
             - clientID
             - issuerURL
+            - usernameClaim
             type: object
           status:
             type: object

--- a/config/crd/bases/authentication.gardener.cloud_openidconnects.yaml
+++ b/config/crd/bases/authentication.gardener.cloud_openidconnects.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   name: openidconnects.authentication.gardener.cloud
 spec:
@@ -64,8 +64,8 @@ spec:
             properties:
               caBundle:
                 description: CABundle is a PEM encoded CA bundle which will be used
-                  to validate the OpenID server's certificate. If unspecified, system
-                  trust roots on the apiserver are used.
+                  to validate the OpenID server's certificate. If unspecified, system's
+                  trusted certificates are used.
                 format: byte
                 type: string
               clientID:
@@ -76,7 +76,6 @@ spec:
                 minLength: 1
                 type: string
               groupsClaim:
-                default: groups
                 description: GroupsClaim, if specified, causes the OIDCAuthenticator
                   to try to populate the user's groups with an ID Token field. If
                   the GroupsClaim field is present in an ID Token the value must be
@@ -87,7 +86,7 @@ spec:
                   group names to be prefixed with the value. A value \"oidc:\" would
                   result in groups like \"oidc:engineering\" and \"oidc:marketing\".
                   \n If not provided, the prefix defaults to \"( .metadata.name )/\".
-                  The value \"-\"\" can be used to disable all prefixing."
+                  The value \"-\" can be used to disable all prefixing."
                 type: string
               issuerURL:
                 description: "IssuerURL is the URL the provider signs ID Tokens as.
@@ -145,19 +144,20 @@ spec:
                   type: string
                 type: array
               usernameClaim:
-                default: sub
                 description: UsernameClaim is the JWT field to use as the user's username.
+                minLength: 1
                 type: string
               usernamePrefix:
                 description: "UsernamePrefix, if specified, causes claims mapping
                   to username to be prefix with the provided value. A value \"oidc:\"
                   would result in usernames like \"oidc:john\". \n If not provided,
-                  the prefix defaults to \"( .metadata.name )/\". The value \"-\"\"
+                  the prefix defaults to \"( .metadata.name )/\". The value \"-\"
                   can be used to disable all prefixing."
                 type: string
             required:
             - clientID
             - issuerURL
+            - usernameClaim
             type: object
           status:
             type: object

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -2,14 +2,14 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM k8s.gcr.io/kube-apiserver:v1.20.0 as kube-apiserver
-FROM quay.io/coreos/etcd:v3.4.15 as etcd
-FROM eu.gcr.io/gardener-project/3rd/golang:1.15.5 AS tools
+FROM k8s.gcr.io/kube-apiserver:v1.22.1 as kube-apiserver
+FROM quay.io/coreos/etcd:v3.5.1 as etcd
+FROM golang:1.16.8 AS tools
 
 COPY --from=kube-apiserver /usr/local/bin/kube-apiserver /testbin/kube-apiserver
 COPY --from=etcd /usr/local/bin/etcd /testbin/etcd
 
-RUN mkdir /tools && cd /tools && go mod init tmp && go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.4.1
+RUN mkdir /tools && cd /tools && go mod init tmp && go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.7.0
 ENV KUBEBUILDER_ASSETS=/testbin
 ENV CGO_ENABLED=0
 ENV GOOS=linux


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR stops the defaulting of username claim to `sub` and groups claim to `groups` for the `openidconnect` resources. Username claim is now a required value.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking user
Username claim for the `openidconnect` resources is now required and is no longer defaulted to `sub`.
```

```breaking user
Groups claim  for the `openidconnect` resources is no longer defaulted to `groups`.
```
