### PR TITLE
Add HSTS Header to mock identity server responses

### DIFF
--- a/test/integration/mock/identityserver.go
+++ b/test/integration/mock/identityserver.go
@@ -166,6 +166,7 @@ func (idp *OIDCIdentityServer) buildWellKnownHandler() func(w http.ResponseWrite
 		host := fmt.Sprintf("https://localhost:%v", idp.ServerSecurePort)
 		wellKnown := fmt.Sprintf(wellKnownResponseTemplate, host)
 		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
 		w.Write([]byte(wellKnown))
 	}
 }
@@ -179,6 +180,7 @@ func (idp *OIDCIdentityServer) buildJWKSHandler() func(w http.ResponseWriter, r 
 		}
 
 		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
 		w.Write(jwks)
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds HSTS Header to mock identity server responses.

**Which issue(s) this PR fixes**:
Fixes #57 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
