### PR TITLE
Empty string is no longer treated as disable prefixing

### DIFF
--- a/controllers/authentication/openidconnect_controller.go
+++ b/controllers/authentication/openidconnect_controller.go
@@ -133,7 +133,7 @@ func (r *OpenIDConnectReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		opts.GroupsClaim = *config.Spec.GroupsClaim
 	}
 
-	if config.Spec.GroupsPrefix != nil {
+	if config.Spec.GroupsPrefix != nil && len(*config.Spec.GroupsPrefix) > 0 {
 		if *config.Spec.GroupsPrefix != authenticationv1alpha1.ClaimPrefixingDisabled {
 			opts.GroupsPrefix = *config.Spec.GroupsPrefix
 		}
@@ -145,7 +145,7 @@ func (r *OpenIDConnectReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		opts.UsernameClaim = *config.Spec.UsernameClaim
 	}
 
-	if config.Spec.UsernamePrefix != nil {
+	if config.Spec.UsernamePrefix != nil && len(*config.Spec.UsernamePrefix) > 0 {
 		if *config.Spec.UsernamePrefix != authenticationv1alpha1.ClaimPrefixingDisabled {
 			opts.UsernamePrefix = *config.Spec.UsernamePrefix
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
Right now empty string value for any of the prefixes (user and groups) is treated as `prefixing disabled` and this should not be the case. This PR fixes this.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Empty string is no longer treated as a valid `usernamePrefix` or `groupsPrefix` value. If empty string is provided in one of these fields then the default prefixing mechanism will be used.
```
