### PR TITLE
Fix unability to disable automount of sa tokens

### DIFF
--- a/charts/oidc-webhook-authenticator/charts/runtime/templates/deployment.yaml
+++ b/charts/oidc-webhook-authenticator/charts/runtime/templates/deployment.yaml
@@ -32,9 +32,7 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
       serviceAccountName: {{ include "oidc-webhook-authenticator.name" . }}
-      {{- if .Values.automountServiceAccountToken }}
       automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
-      {{- end }}
       containers:
       - name: {{ include "oidc-webhook-authenticator.name" . }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a bug. Previously it was not possible to disable the automount serviceaccount token feature.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
It is now possible set `automountServiceAccountToken: false` for the OWA deployment by setting `.Values.automountServiceAccountToken`. 
```
