### PR TITLE
Use the default OCI image builder

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -10,7 +10,6 @@ oidc-webhook-authenticator:
       version:
         preprocess: inject-commit-hash
       publish:
-        oci-builder: kaniko
         dockerimages:
           oidc-webhook-authenticator:
             registry: gcr-readwrite


### PR DESCRIPTION
**What this PR does / why we need it**:
Unpin kaniko in favor of the default OCI builder, currently Docker - ref: https://github.com/gardener/cc-utils/pull/661

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
