### PR TITLE
Bump go version to 1.17.7 and alpine to 3.15.0

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -19,9 +19,9 @@ oidc-webhook-authenticator:
             tag_as_latest: false
     steps:
       check:
-        image: 'golang:1.16'
+        image: 'golang:1.17.7'
       test:
-        image: 'golang:1.16'
+        image: 'golang:1.17.7'
   jobs:
     head-update:
       traits:

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Build the manager binary
-FROM golang:1.17.6 AS builder
+FROM golang:1.17.7 AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -22,7 +22,7 @@ COPY webhook/ webhook/
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o oidc-webhook-authenticator cmd/oidc-webhook-authenticator/authenticator.go
 
-FROM alpine:3.13.6
+FROM alpine:3.15.0
 RUN apk --no-cache add ca-certificates
 WORKDIR /
 COPY --from=builder /workspace/oidc-webhook-authenticator .

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -4,7 +4,7 @@
 
 FROM k8s.gcr.io/kube-apiserver:v1.22.1 as kube-apiserver
 FROM quay.io/coreos/etcd:v3.5.1 as etcd
-FROM golang:1.17.6 AS tools
+FROM golang:1.17.7 AS tools
 
 COPY --from=kube-apiserver /usr/local/bin/kube-apiserver /testbin/kube-apiserver
 COPY --from=etcd /usr/local/bin/etcd /testbin/etcd


### PR DESCRIPTION
**What this PR does / why we need it**:
Bump versions:
`go` to 1.17.7
`alpine` to 3.15.0

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
OWA is now built using `golang:1.17.7` and `alpine:3.15.0`.
```
