### PR TITLE
Add checksums for kubeconfigs to deployment spec

### DIFF
--- a/charts/oidc-webhook-authenticator/charts/runtime/templates/deployment.yaml
+++ b/charts/oidc-webhook-authenticator/charts/runtime/templates/deployment.yaml
@@ -27,6 +27,12 @@ spec:
     metadata:
       annotations:
         checksum/secret-oidc-webhook-authenticator-tls: {{ include (print $.Template.BasePath "/secret-tls.yaml") . | sha256sum }}
+        {{- if .Values.kubeconfig }}
+        checksum/secret-oidc-webhook-authenticator-kubeconfig: {{ include (print $.Template.BasePath "/secret-kubeconfig.yaml") . | sha256sum }}
+        {{- end }}
+        {{- if .Values.auth.kubeconfig }}
+        checksum/secret-oidc-webhook-authenticator-auth-kubeconfig: {{ include (print $.Template.BasePath "/secret-auth-kubeconfig.yaml") . | sha256sum }}
+        {{- end }}
       labels:
         app.kubernetes.io/name: {{ include "oidc-webhook-authenticator.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds checksums for the kubeconfigs to the owa deployment. This will trigger deployment rollout when `helm upgrade --install` is performed with only changed kubecofigs. Previously a rollout was not being triggered since the deployment spec was unchanged.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Helm upgrade will now correctly trigger a deployment rollout when a kubeconfig secret is changed. 
```
