### PR TITLE
Image tag can be now also sha256 digest

### DIFF
--- a/charts/oidc-webhook-authenticator/charts/runtime/templates/_helpers.tpl
+++ b/charts/oidc-webhook-authenticator/charts/runtime/templates/_helpers.tpl
@@ -1,3 +1,11 @@
 {{- define "oidc-webhook-authenticator.name" -}}
 oidc-webhook-authenticator
 {{- end -}}
+
+{{- define "image" -}}
+{{- if hasPrefix "sha256:" (required "$.tag is required" $.tag) -}}
+{{ required "$.repository is required" $.repository }}@{{ required "$.tag is required" $.tag }}
+{{- else -}}
+{{ required "$.repository is required" $.repository }}:{{ required "$.tag is required" $.tag }}
+{{- end -}}
+{{- end -}}

--- a/charts/oidc-webhook-authenticator/charts/runtime/templates/deployment.yaml
+++ b/charts/oidc-webhook-authenticator/charts/runtime/templates/deployment.yaml
@@ -59,7 +59,7 @@ spec:
       {{- end }}
       containers:
       - name: {{ include "oidc-webhook-authenticator.name" . }}
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        image: {{ include "image" .Values.image }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         args:
         - --tls-cert-file=/var/run/oidc-webhook-authenticator/tls/tls.crt


### PR DESCRIPTION
**What this PR does / why we need it**:
Image tag can be now also sha256 digest

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
It is now possible the helm chart value `image.tag` to be sha256 digest.
```
