### PR TITLE
Upgrade go version and use distroless as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,11 +22,9 @@ COPY webhook/ webhook/
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o oidc-webhook-authenticator cmd/oidc-webhook-authenticator/authenticator.go
 
-FROM alpine:3.15.4
-RUN apk --no-cache add ca-certificates
+FROM gcr.io/distroless/static-debian11:nonroot
 WORKDIR /
 COPY --from=builder /workspace/oidc-webhook-authenticator .
-USER 65532:65532
 EXPOSE 10443/tcp
 
 LABEL org.opencontainers.image.authors="Gardener contributors"

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Build the manager binary
-FROM golang:1.18.3 AS builder
+FROM golang:1.18.4 AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -4,7 +4,7 @@
 
 FROM k8s.gcr.io/kube-apiserver:v1.22.1 as kube-apiserver
 FROM quay.io/coreos/etcd:v3.5.1 as etcd
-FROM golang:1.18.3 AS tools
+FROM golang:1.18.4 AS tools
 
 COPY --from=kube-apiserver /usr/local/bin/kube-apiserver /testbin/kube-apiserver
 COPY --from=etcd /usr/local/bin/etcd /testbin/etcd


### PR DESCRIPTION
**What this PR does / why we need it**:
Upgrades go version to 1.18.4 and changes base container image to distroless.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
OWA is now built using go version `1.18.4`.
```

```other operator
OWA now uses `distroless` as a base container image.
```
