### PR TITLE
Update go version to 1.19.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Build the manager binary
-FROM golang:1.18.4 AS builder
+FROM golang:1.19.1 AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -4,7 +4,7 @@
 
 FROM k8s.gcr.io/kube-apiserver:v1.22.1 as kube-apiserver
 FROM quay.io/coreos/etcd:v3.5.1 as etcd
-FROM golang:1.18.4 AS tools
+FROM golang:1.19.1 AS tools
 
 COPY --from=kube-apiserver /usr/local/bin/kube-apiserver /testbin/kube-apiserver
 COPY --from=etcd /usr/local/bin/etcd /testbin/etcd


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates go version used for build to `1.19.1`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
OWA is now built using go version `1.19.1`.
```
