### PR TITLE
Build multi-arch images for amd64 and arm64

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -10,6 +10,10 @@ oidc-webhook-authenticator:
       version:
         preprocess: inject-commit-hash
       publish:
+        oci-builder: docker-buildx
+        platforms:
+        - linux/amd64
+        - linux/arm64
         dockerimages:
           oidc-webhook-authenticator:
             registry: gcr-readwrite

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@
 # Build the manager binary
 FROM golang:1.19.5 AS builder
 
+ARG TARGETARCH
 WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY go.mod go.mod
@@ -20,7 +21,7 @@ COPY cmd/ cmd/
 COPY webhook/ webhook/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o oidc-webhook-authenticator cmd/oidc-webhook-authenticator/authenticator.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH GO111MODULE=on go build -a -o oidc-webhook-authenticator cmd/oidc-webhook-authenticator/authenticator.go
 
 FROM gcr.io/distroless/static-debian11:nonroot
 WORKDIR /

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@
 IMG ?= oidc-webhook-authenticator:latest
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:trivialVersions=false,preserveUnknownFields=false"
+GOARCH      ?= $(shell go env GOARCH)
 
 # Get the currently used
 # install path (in GOPATH/bin, unless GOBIN is set)
@@ -56,13 +57,13 @@ start-dev-container: tools-image ## Run go vet against code.
 	docker run --rm --name=odic-dev-container -v $(shell pwd):/workspace --workdir /workspace /bin/bash
 
 build: generate fmt vet ## Build manager binary.
-	go build -o bin/oidc-webhook-authenticator ./cmd/oidc-webhook-authenticator/authenticator.go
+	GOARCH=$(GOARCH) go build -o bin/oidc-webhook-authenticator ./cmd/oidc-webhook-authenticator/authenticator.go
 
 run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./cmd/oidc-webhook-authenticator/authenticator.go
 
 docker-build: ## Build docker image with the manager.
-	docker build -t ${IMG} .
+	docker build --build-arg TARGETARCH=$(GOARCH) -t ${IMG} .
 
 docker-push: ## Push docker image with the manager.
 	docker push ${IMG}


### PR DESCRIPTION
**What this PR does / why we need it**:
Build multi-arch images for amd64 and arm64

**Which issue(s) this PR fixes**:
Fixes #92 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
The docker image of this repository now supports `linux/arm64`.
```
