### PR TITLE
[Charts] Additional labels and PDB

### DIFF
--- a/charts/oidc-webhook-authenticator/charts/runtime/templates/deployment.yaml
+++ b/charts/oidc-webhook-authenticator/charts/runtime/templates/deployment.yaml
@@ -11,6 +11,11 @@ metadata:
     app.kubernetes.io/name: {{ include "oidc-webhook-authenticator.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.additionalLabels.deployment }}
+{{- range .Values.additionalLabels.deployment }}
+{{ toYaml . | trim | indent 4 }}
+{{- end }}
+{{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   revisionHistoryLimit: 5

--- a/charts/oidc-webhook-authenticator/charts/runtime/templates/deployment.yaml
+++ b/charts/oidc-webhook-authenticator/charts/runtime/templates/deployment.yaml
@@ -12,9 +12,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- if .Values.additionalLabels.deployment }}
-{{- range .Values.additionalLabels.deployment }}
-{{ toYaml . | trim | indent 4 }}
-{{- end }}
+{{ toYaml .Values.additionalLabels.deployment | trim | indent 4 }}
 {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}

--- a/charts/oidc-webhook-authenticator/charts/runtime/templates/deployment.yaml
+++ b/charts/oidc-webhook-authenticator/charts/runtime/templates/deployment.yaml
@@ -39,6 +39,9 @@ spec:
       labels:
         app.kubernetes.io/name: {{ include "oidc-webhook-authenticator.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- if .Values.additionalLabels.deployment }}
+        {{- toYaml .Values.additionalLabels.deployment | trim | nindent 8 }}
+        {{- end }}
     spec:
       serviceAccountName: {{ include "oidc-webhook-authenticator.name" . }}
       automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}

--- a/charts/oidc-webhook-authenticator/charts/runtime/templates/hpa.yaml
+++ b/charts/oidc-webhook-authenticator/charts/runtime/templates/hpa.yaml
@@ -3,6 +3,34 @@
 # SPDX-License-Identifier: Apache-2.0
 
 {{- if .Values.autoscaling.hpa.enabled }}
+{{- if semverCompare ">= 1.23-0" .Capabilities.KubeVersion.GitVersion }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "oidc-webhook-authenticator.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ include "oidc-webhook-authenticator.name" . }}
+{{- if .Values.additionalLabels.hpa }}
+{{- range .Values.additionalLabels.hpa }}
+{{ toYaml . | trim | indent 4 }}
+{{- end }}
+{{- end }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "oidc-webhook-authenticator.name" . }}
+  minReplicas: {{ .Values.autoscaling.hpa.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.hpa.maxReplicas }}
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.autoscaling.hpa.cpuTargetAverageUtilization }}
+{{- else -}}
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
@@ -10,6 +38,11 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "oidc-webhook-authenticator.name" . }}
+{{- if .Values.additionalLabels.hpa }}
+{{- range .Values.additionalLabels.hpa }}
+{{ toYaml . | trim | indent 4 }}
+{{- end }}
+{{- end }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
@@ -22,4 +55,5 @@ spec:
     resource:
       name: cpu
       targetAverageUtilization: {{ .Values.autoscaling.hpa.cpuTargetAverageUtilization }}
+{{- end }}
 {{- end }}

--- a/charts/oidc-webhook-authenticator/charts/runtime/templates/hpa.yaml
+++ b/charts/oidc-webhook-authenticator/charts/runtime/templates/hpa.yaml
@@ -12,9 +12,7 @@ metadata:
   labels:
     app.kubernetes.io/name: {{ include "oidc-webhook-authenticator.name" . }}
 {{- if .Values.additionalLabels.hpa }}
-{{- range .Values.additionalLabels.hpa }}
-{{ toYaml . | trim | indent 4 }}
-{{- end }}
+{{ toYaml .Values.additionalLabels.hpa | trim | indent 4 }}
 {{- end }}
 spec:
   scaleTargetRef:
@@ -39,9 +37,7 @@ metadata:
   labels:
     app.kubernetes.io/name: {{ include "oidc-webhook-authenticator.name" . }}
 {{- if .Values.additionalLabels.hpa }}
-{{- range .Values.additionalLabels.hpa }}
-{{ toYaml . | trim | indent 4 }}
-{{- end }}
+{{ toYaml .Values.additionalLabels.hpa | trim | indent 4 }}
 {{- end }}
 spec:
   scaleTargetRef:

--- a/charts/oidc-webhook-authenticator/charts/runtime/templates/poddisruptionbudget.yaml
+++ b/charts/oidc-webhook-authenticator/charts/runtime/templates/poddisruptionbudget.yaml
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+---
+{{- if semverCompare ">= 1.21-0" .Capabilities.KubeVersion.GitVersion }}
+apiVersion: policy/v1
+{{- else }}
+apiVersion: policy/v1beta1
+{{- end }}
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "oidc-webhook-authenticator.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ include "oidc-webhook-authenticator.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "oidc-webhook-authenticator.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/oidc-webhook-authenticator/charts/runtime/values.yaml
+++ b/charts/oidc-webhook-authenticator/charts/runtime/values.yaml
@@ -60,5 +60,5 @@ serviceAccountTokenVolumeProjection:
 apiAudiences: []
 
 additionalLabels:
-  hpa: []
-  deployment: []
+  hpa: {}
+  deployment: {}

--- a/charts/oidc-webhook-authenticator/charts/runtime/values.yaml
+++ b/charts/oidc-webhook-authenticator/charts/runtime/values.yaml
@@ -58,3 +58,7 @@ serviceAccountTokenVolumeProjection:
 
 # List with identifiers of the API. Tokens used against the API should be bound to at least one of these audiences.
 apiAudiences: []
+
+additionalLabels:
+  hpa: []
+  deployment: []

--- a/charts/oidc-webhook-authenticator/values.yaml
+++ b/charts/oidc-webhook-authenticator/values.yaml
@@ -83,3 +83,7 @@ runtime:
 
   # List with identifiers of the API. Tokens used against the API should be bound to at least one of these audiences.
   apiAudiences: []
+
+  additionalLabels:
+    deployment: []
+    hpa: []

--- a/charts/oidc-webhook-authenticator/values.yaml
+++ b/charts/oidc-webhook-authenticator/values.yaml
@@ -85,5 +85,5 @@ runtime:
   apiAudiences: []
 
   additionalLabels:
-    deployment: []
-    hpa: []
+    deployment: {}
+    hpa: {}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a pdb for the OWA deployment as well as the ability to configure additional labels for the `deployment` and `hpa` resources. These labels can be used to configure high availability requirements via the gardener ha webhook. See more details [here](https://gardener.cloud/docs/gardener/concepts/resource-manager/#high-availability-config).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
OWA charts now also create a `PodDisruptionBudget` resource.
```

```feature operator
OWA charts now support adding additional labels to its `hpa` and `deployment` resources by setting `.Values.runtime.additionalLabels.{deployment,hpa}`.
```
