### PR TITLE
Always add pod anti affinity to deployment

### DIFF
--- a/charts/oidc-webhook-authenticator/charts/runtime/templates/deployment.yaml
+++ b/charts/oidc-webhook-authenticator/charts/runtime/templates/deployment.yaml
@@ -39,7 +39,6 @@ spec:
     spec:
       serviceAccountName: {{ include "oidc-webhook-authenticator.name" . }}
       automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
-      {{- if or .Values.autoscaling.hpa.enabled (gt (int .Values.replicaCount) 1) }}
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
@@ -56,7 +55,6 @@ spec:
                   - {{ .Release.Name }}
               topologyKey: kubernetes.io/hostname
             weight: 1
-      {{- end }}
       containers:
       - name: {{ include "oidc-webhook-authenticator.name" . }}
         image: {{ include "image" .Values.image }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Always add pod anti affinity to OWA deployment because the number of replicas can be modified runtime (by hpa, webhooks or others).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The OWA deployment now always configures a pod anti affinity rule that prefers OWA replicas to be scheduled on different nodes.
```
