### PR TITLE
Add runtime default seccomp profile

### DIFF
--- a/charts/oidc-webhook-authenticator/charts/runtime/templates/deployment.yaml
+++ b/charts/oidc-webhook-authenticator/charts/runtime/templates/deployment.yaml
@@ -45,6 +45,10 @@ spec:
     spec:
       serviceAccountName: {{ include "oidc-webhook-authenticator.name" . }}
       automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds `RuntimeDefault` as a seccomp profile for OWA and ensures that the OWA container is ran as non root.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
OWA deployment now runs with `RuntimeDefault` seccomp profile.
```
