### PR TITLE
Instrument secure server with generic http metrics exposed via diagnostic server

### DIFF
--- a/charts/oidc-webhook-authenticator/charts/runtime/templates/deployment.yaml
+++ b/charts/oidc-webhook-authenticator/charts/runtime/templates/deployment.yaml
@@ -88,7 +88,7 @@ spec:
         livenessProbe:
           failureThreshold: 3
           httpGet:
-            path: /healthz
+            path: /livez
             port: {{ .Values.diagnosticPort }}
             scheme: HTTP
           initialDelaySeconds: 10
@@ -96,7 +96,7 @@ spec:
         readinessProbe:
           failureThreshold: 2
           httpGet:
-            path: /healthz
+            path: /readyz
             port: {{ .Values.diagnosticPort }}
             scheme: HTTP
           initialDelaySeconds: 10

--- a/charts/oidc-webhook-authenticator/charts/runtime/templates/deployment.yaml
+++ b/charts/oidc-webhook-authenticator/charts/runtime/templates/deployment.yaml
@@ -84,21 +84,20 @@ spec:
         - --api-audiences={{ .Values.apiAudiences | join "," }}
         {{- end }}
         - --authorization-always-allow-paths={{ .Values.auth.authorizationAlwaysAllowPaths | join "," }}
-        - --diagnostic-address=":{{ .Values.diagnosticPort }}"
         livenessProbe:
           failureThreshold: 3
           httpGet:
             path: /livez
-            port: {{ .Values.diagnosticPort }}
-            scheme: HTTP
+            port: 10443
+            scheme: HTTPS
           initialDelaySeconds: 10
           periodSeconds: 20
         readinessProbe:
           failureThreshold: 2
           httpGet:
             path: /readyz
-            port: {{ .Values.diagnosticPort }}
-            scheme: HTTP
+            port: 10443
+            scheme: HTTPS
           initialDelaySeconds: 10
           periodSeconds: 15
         resources:

--- a/charts/oidc-webhook-authenticator/charts/runtime/templates/deployment.yaml
+++ b/charts/oidc-webhook-authenticator/charts/runtime/templates/deployment.yaml
@@ -84,20 +84,21 @@ spec:
         - --api-audiences={{ .Values.apiAudiences | join "," }}
         {{- end }}
         - --authorization-always-allow-paths={{ .Values.auth.authorizationAlwaysAllowPaths | join "," }}
+        - --diagnostic-address=":{{ .Values.diagnosticPort }}"
         livenessProbe:
           failureThreshold: 3
           httpGet:
             path: /healthz
-            port: 10443
-            scheme: HTTPS
+            port: {{ .Values.diagnosticPort }}
+            scheme: HTTP
           initialDelaySeconds: 10
           periodSeconds: 20
         readinessProbe:
           failureThreshold: 2
           httpGet:
             path: /healthz
-            port: 10443
-            scheme: HTTPS
+            port: {{ .Values.diagnosticPort }}
+            scheme: HTTP
           initialDelaySeconds: 10
           periodSeconds: 15
         resources:

--- a/charts/oidc-webhook-authenticator/charts/runtime/values.yaml
+++ b/charts/oidc-webhook-authenticator/charts/runtime/values.yaml
@@ -33,14 +33,13 @@ webhookConfig:
 kubeconfig:
 
 auth:
+  # /metrics, /readyz, /livez endpoints are always allowed
   # Kubeconfig to the target authentication and authorization cluster. In-cluster configuration will be used if not specified.
   # If automountServiceAccountToken is set to `true` then this value is required because in-cluster configuration will not work.
   kubeconfig:
   # A list of HTTP paths to skip during authorization.
   authorizationAlwaysAllowPaths:
   - /webhooks/validating
-
-diagnosticPort: 8080
 
 resources:
   requests:

--- a/charts/oidc-webhook-authenticator/charts/runtime/values.yaml
+++ b/charts/oidc-webhook-authenticator/charts/runtime/values.yaml
@@ -38,8 +38,9 @@ auth:
   kubeconfig:
   # A list of HTTP paths to skip during authorization.
   authorizationAlwaysAllowPaths:
-  - /healthz
   - /webhooks/validating
+
+diagnosticPort: 8080
 
 resources:
   requests:

--- a/charts/oidc-webhook-authenticator/values.yaml
+++ b/charts/oidc-webhook-authenticator/values.yaml
@@ -58,14 +58,13 @@ runtime:
   kubeconfig:
 
   auth:
+    # /metrics, /readyz, /livez endpoints are always allowed
     # Kubeconfig to the target authentication and authorization cluster. In-cluster configuration will be used if not specified.
     # If automountServiceAccountToken is set to `true` then this value is required because in-cluster configuration will not work.
     kubeconfig:
     # A list of HTTP paths to skip during authorization.
     authorizationAlwaysAllowPaths:
     - /webhooks/validating
-
-  diagnosticPort: 8080
 
   resources:
     requests:

--- a/charts/oidc-webhook-authenticator/values.yaml
+++ b/charts/oidc-webhook-authenticator/values.yaml
@@ -55,7 +55,7 @@ runtime:
 
   # Kubeconfig to the target cluster. In-cluster configuration will be used if not specified.
   # If automountServiceAccountToken is set to `true` then this value is required because in-cluster configuration will not work.
-  kubeconfig: 
+  kubeconfig:
 
   auth:
     # Kubeconfig to the target authentication and authorization cluster. In-cluster configuration will be used if not specified.
@@ -63,8 +63,9 @@ runtime:
     kubeconfig:
     # A list of HTTP paths to skip during authorization.
     authorizationAlwaysAllowPaths:
-    - /healthz
     - /webhooks/validating
+
+  diagnosticPort: 8080
 
   resources:
     requests:

--- a/cmd/oidc-webhook-authenticator/app/oidc_webhook_authenticator.go
+++ b/cmd/oidc-webhook-authenticator/app/oidc_webhook_authenticator.go
@@ -135,6 +135,8 @@ func run(ctx context.Context, opts *options.Config, setupLog logr.Logger) error 
 
 	diagnosticMux := http.NewServeMux()
 	healthz.InstallHandler(diagnosticMux, healthz.LogHealthz, healthz.PingHealthz)
+	healthz.InstallReadyzHandler(diagnosticMux, healthz.LogHealthz, healthz.PingHealthz)
+	healthz.InstallLivezHandler(diagnosticMux, healthz.LogHealthz, healthz.PingHealthz)
 	diagnosticMux.Handle("/metrics", promhttp.Handler())
 	go func() {
 		setupLog.Info("Starting diagnostic server", "address", opts.DiagnosticAddr.Addr)

--- a/cmd/oidc-webhook-authenticator/app/oidc_webhook_authenticator.go
+++ b/cmd/oidc-webhook-authenticator/app/oidc_webhook_authenticator.go
@@ -10,9 +10,12 @@ import (
 	"net/http"
 	"os"
 
+	authenticationv1alpha1 "github.com/gardener/oidc-webhook-authenticator/apis/authentication/v1alpha1"
 	"github.com/gardener/oidc-webhook-authenticator/cmd/oidc-webhook-authenticator/app/options"
+	authcontroller "github.com/gardener/oidc-webhook-authenticator/controllers/authentication"
 	"github.com/gardener/oidc-webhook-authenticator/webhook/authentication"
 	"github.com/gardener/oidc-webhook-authenticator/webhook/metrics"
+
 	"github.com/go-logr/logr"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/spf13/cobra"
@@ -23,17 +26,14 @@ import (
 	genericfilters "k8s.io/apiserver/pkg/server/filters"
 	"k8s.io/apiserver/pkg/server/healthz"
 	"k8s.io/apiserver/pkg/server/mux"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	cliflag "k8s.io/component-base/cli/flag"
 	"k8s.io/component-base/cli/globalflag"
 	"k8s.io/component-base/version/verflag"
-	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
-
-	authenticationv1alpha1 "github.com/gardener/oidc-webhook-authenticator/apis/authentication/v1alpha1"
-	authcontroller "github.com/gardener/oidc-webhook-authenticator/controllers/authentication"
-	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
-	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
 // NewOIDCWebhookAuthenticatorCommand is the root command for OIDC webhook authenticator.

--- a/cmd/oidc-webhook-authenticator/app/options/options.go
+++ b/cmd/oidc-webhook-authenticator/app/options/options.go
@@ -19,15 +19,10 @@ type Options struct {
 	Authentication *genericoptions.DelegatingAuthenticationOptions
 	Authorization  *genericoptions.DelegatingAuthorizationOptions
 	ResyncPeriod   resyncPeriod
-	DiagnosticAddr bindAddr
 }
 
 type resyncPeriod struct {
 	Duration time.Duration
-}
-
-type bindAddr struct {
-	Addr string
 }
 
 // NewOptions return options with default values.
@@ -40,7 +35,6 @@ func NewOptions() *Options {
 		Authentication: recommended.Authentication,
 		Authorization:  recommended.Authorization,
 		ResyncPeriod:   resyncPeriod{},
-		DiagnosticAddr: bindAddr{},
 	}
 
 	opts.Authentication.RemoteKubeConfigFileOptional = true
@@ -60,7 +54,6 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	o.Authentication.AddFlags(fs)
 	o.Authorization.AddFlags(fs)
 	o.ResyncPeriod.AddFlags(fs)
-	o.DiagnosticAddr.AddFlags(fs)
 }
 
 func (s *resyncPeriod) AddFlags(fs *pflag.FlagSet) {
@@ -71,29 +64,12 @@ func (s *resyncPeriod) AddFlags(fs *pflag.FlagSet) {
 	fs.DurationVar(&s.Duration, "resync-period", time.Second*0, "resync period")
 }
 
-func (s *bindAddr) AddFlags(fs *pflag.FlagSet) {
-	if s == nil {
-		return
-	}
-
-	fs.StringVar(&s.Addr, "diagnostic-address", ":8080", "bind address for the diagnostic server (health checks, metrics, etc.)")
-}
-
 func (s *resyncPeriod) ApplyTo(c *resyncPeriod) error {
 	if s == nil {
 		return nil
 	}
 	c.Duration = time.Minute * 60
 
-	return nil
-}
-
-func (s *bindAddr) ApplyTo(d *bindAddr) error {
-	if s == nil {
-		return nil
-	}
-
-	d.Addr = s.Addr
 	return nil
 }
 
@@ -110,9 +86,6 @@ func (o *Options) ApplyTo(server *Config) error {
 		return err
 	}
 	if err := o.ResyncPeriod.ApplyTo(&server.ResyncPeriod); err != nil {
-		return err
-	}
-	if err := o.DiagnosticAddr.ApplyTo(&server.DiagnosticAddr); err != nil {
 		return err
 	}
 	return nil
@@ -134,5 +107,4 @@ type Config struct {
 	Authorization  apiserver.AuthorizationInfo
 	SecureServing  *apiserver.SecureServingInfo
 	ResyncPeriod   resyncPeriod
-	DiagnosticAddr bindAddr
 }

--- a/controllers/authentication/openidconnect_controller.go
+++ b/controllers/authentication/openidconnect_controller.go
@@ -10,7 +10,7 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"mime"
 	"net/http"
 	"strings"
@@ -394,7 +394,7 @@ func remoteKeySet(ctx context.Context, issuer string, cabundle []byte) (gooidc.K
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("unable to read response body: %v", err)
 	}

--- a/test/integration/integration_suite_test.go
+++ b/test/integration/integration_suite_test.go
@@ -21,6 +21,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	authenticationv1 "k8s.io/api/authentication/v1"
+	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -40,6 +41,7 @@ import (
 var (
 	apiServerSecurePort                          int
 	apiserverToken                               string
+	defaultServiceAccountToken                   string
 	testEnv                                      *oidctestenv.OIDCWebhookTestEnvironment
 	oidcOut, oidcErr, apiserverOut, apiserverErr bytes.Buffer
 	k8sClient                                    client.Client
@@ -122,6 +124,26 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	apiserverToken = resp.Status.Token
+
+	defaultServiceAccount := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "default",
+		},
+	}
+	_, err = clientset.CoreV1().ServiceAccounts("default").Create(ctx, defaultServiceAccount, metav1.CreateOptions{})
+	Expect(err).NotTo(HaveOccurred())
+
+	resp, err = clientset.CoreV1().ServiceAccounts("default").CreateToken(ctx, "default", &authenticationv1.TokenRequest{
+		Spec: authenticationv1.TokenRequestSpec{
+			ExpirationSeconds: &ttl,
+		},
+	}, metav1.CreateOptions{})
+
+	Expect(err).NotTo(HaveOccurred())
+
+	defaultServiceAccountToken = resp.Status.Token
+
 }, 60)
 
 var _ = AfterSuite(func() {

--- a/test/integration/integration_suite_test.go
+++ b/test/integration/integration_suite_test.go
@@ -10,7 +10,6 @@ import (
 	"bytes"
 	"context"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -152,7 +151,7 @@ var _ = AfterSuite(func() {
 
 		dumpFn := func(filename string, bytes []byte, perm fs.FileMode) {
 			if len(bytes) > 0 {
-				ioutil.WriteFile(filename, bytes, perm)
+				os.WriteFile(filename, bytes, perm)
 			}
 		}
 

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -532,6 +532,35 @@ var _ = Describe("Integration", func() {
 
 	Context("Authenticating user against the webhook authenticator via token from a trusted identity provider", func() {
 		var (
+			makeTokenReviewRequestAndAssertError = func(token, userToken string, ca []byte, expectedStatusCode int, expectedErrMsgPart string) {
+				caCertPool := x509.NewCertPool()
+				caCertPool.AppendCertsFromPEM(ca)
+
+				review := &authenticationv1.TokenReview{
+					Spec: authenticationv1.TokenReviewSpec{
+						Token: userToken,
+					},
+				}
+				tr := &http.Transport{
+					TLSClientConfig: &tls.Config{RootCAs: caCertPool},
+				}
+				client := &http.Client{Transport: tr}
+				body, err := json.Marshal(review)
+				Expect(err).NotTo(HaveOccurred())
+				req, err := http.NewRequest("POST", "https://localhost:10443/validate-token", bytes.NewReader(body))
+				Expect(err).NotTo(HaveOccurred())
+				req.Header.Set("Authorization", fmt.Sprintf("Bearer %v", token))
+
+				res, err := client.Do(req)
+				Expect(err).NotTo(HaveOccurred())
+
+				responseBytes, err := ioutil.ReadAll(res.Body)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(string(responseBytes)).To(ContainSubstring(expectedErrMsgPart))
+
+				Expect(res.StatusCode).To(Equal(expectedStatusCode))
+			}
+
 			makeTokenReviewRequest = func(apiserverToken, userToken string, ca []byte, expectToAuthenticate bool) *authenticationv1.TokenReview {
 				caCertPool := x509.NewCertPool()
 				caCertPool.AppendCertsFromPEM(ca)
@@ -589,6 +618,14 @@ var _ = Describe("Integration", func() {
 				return reviewResponse
 			}
 		)
+
+		It("Should not authenticate the token review request", func() {
+			makeTokenReviewRequestAndAssertError("invalid-token", "token", testEnv.OIDCServerCA(), http.StatusUnauthorized, "Unauthorized")
+		})
+
+		It("Should not authorize the token review request", func() {
+			makeTokenReviewRequestAndAssertError(defaultServiceAccountToken, "token", testEnv.OIDCServerCA(), http.StatusForbidden, `User \"system:serviceaccount:default:default\" cannot post path \"/validate-token\"`)
+		})
 
 		It("Should authenticate token with default prefixes for group and user", func() {
 			idp := createAndStartIDPServer(1)

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -14,7 +14,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -554,7 +554,7 @@ var _ = Describe("Integration", func() {
 				res, err := client.Do(req)
 				Expect(err).NotTo(HaveOccurred())
 
-				responseBytes, err := ioutil.ReadAll(res.Body)
+				responseBytes, err := io.ReadAll(res.Body)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(string(responseBytes)).To(ContainSubstring(expectedErrMsgPart))
 
@@ -586,7 +586,7 @@ var _ = Describe("Integration", func() {
 						res, err := client.Do(req)
 						Expect(err).NotTo(HaveOccurred())
 
-						responseBytes, err := ioutil.ReadAll(res.Body)
+						responseBytes, err := io.ReadAll(res.Body)
 						Expect(err).NotTo(HaveOccurred())
 
 						err = json.Unmarshal(responseBytes, reviewResponse)
@@ -603,7 +603,7 @@ var _ = Describe("Integration", func() {
 						res, err := client.Do(req)
 						Expect(err).NotTo(HaveOccurred())
 
-						responseBytes, err := ioutil.ReadAll(res.Body)
+						responseBytes, err := io.ReadAll(res.Body)
 						Expect(err).NotTo(HaveOccurred())
 
 						err = json.Unmarshal(responseBytes, reviewResponse)

--- a/webhook/metrics/metrics.go
+++ b/webhook/metrics/metrics.go
@@ -77,7 +77,7 @@ func NewTimerForTokenValidationRequest() *prometheus.Timer {
 }
 
 // InstrumentedHandler instrument http handler with request generic metrics.
-func InstrumentedHandler(path string, hookRaw http.Handler) http.Handler {
+func InstrumentedHandler(path string, handler http.Handler) http.Handler {
 	var (
 		label    = prometheus.Labels{"path": path}
 		latency  = requestLatency.MustCurryWith(label)
@@ -87,6 +87,6 @@ func InstrumentedHandler(path string, hookRaw http.Handler) http.Handler {
 
 	return promhttp.InstrumentHandlerDuration(latency,
 		promhttp.InstrumentHandlerCounter(total,
-			promhttp.InstrumentHandlerInFlight(inFlight, hookRaw),
+			promhttp.InstrumentHandlerInFlight(inFlight, handler),
 		))
 }

--- a/webhook/metrics/metrics.go
+++ b/webhook/metrics/metrics.go
@@ -5,8 +5,10 @@
 package metrics
 
 import (
+	"net/http"
+
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 const (
@@ -20,16 +22,39 @@ var (
 		Help:      "Number of token validation requests.",
 	}, []string{"result"})
 
-	durationTokenValidation = promauto.NewHistogramVec(prometheus.HistogramOpts{
+	durationTokenValidation = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Name:      "token_validation_time_seconds",
 		Subsystem: subsystemName,
 		Help:      "Duration of HTTP token validation requests.",
 	}, []string{})
+
+	requestLatency = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:      "path_latency_seconds",
+		Subsystem: subsystemName,
+		Help:      "Histogram of the latency of processing HTTP requests",
+	},
+		[]string{"path"},
+	)
+
+	requestTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name:      "path_requests_total",
+		Subsystem: subsystemName,
+		Help:      "Total number of HTTP requests by path and code.",
+	},
+		[]string{"path", "code"},
+	)
+
+	requestInFlight = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name:      "path_requests_in_flight",
+		Subsystem: subsystemName,
+		Help:      "Number of currently server HTTP requests.",
+	},
+		[]string{"path"},
+	)
 )
 
 func init() {
-	prometheus.Register(totalTokenValidations)
-	prometheus.Register(durationTokenValidation)
+	prometheus.MustRegister(totalTokenValidations, durationTokenValidation, requestLatency, requestTotal, requestInFlight)
 }
 
 // IncTotalRequestValidationErrors increments the total number of errors occured during token validation requests
@@ -49,4 +74,19 @@ func IncTotalRequestValidations(authenticated bool) {
 // NewTimerForTokenValidationRequest creates a new timer for measuring the time needed for a token validation request to execute
 func NewTimerForTokenValidationRequest() *prometheus.Timer {
 	return prometheus.NewTimer(durationTokenValidation.WithLabelValues())
+}
+
+// InstrumentedHandler instrument http handler with request generic metrics.
+func InstrumentedHandler(path string, hookRaw http.Handler) http.Handler {
+	var (
+		label    = prometheus.Labels{"path": path}
+		latency  = requestLatency.MustCurryWith(label)
+		total    = requestTotal.MustCurryWith(label)
+		inFlight = requestInFlight.With(label)
+	)
+
+	return promhttp.InstrumentHandlerDuration(latency,
+		promhttp.InstrumentHandlerCounter(total,
+			promhttp.InstrumentHandlerInFlight(inFlight, hookRaw),
+		))
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Instrument secure server with generic http metrics exposed via diagnostic server

A new plain-text HTTP server is added, so called diagnostic server.
It now takes over and severs the `/metrics` and `/healthz` handlers. Additionally, servers `/readyz` and `/livez` endpoints.
The secure server is instrumented with the new generic metrics on handler level, as well as on global level.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The following endpoints no longer require authentication and authorization:
 - /livez
 - /readyz
 - /metrics
```

```breaking operator
The `/healthz` endpoint is no longer served. Please use `/livez` or `/readyz` instead.
```

```feature operator
Critical endpoints are now instrumented with additional http metrics that will help improve observability capabilities.
```
