### PR TITLE
Add authz to /metrics

### DIFF
--- a/charts/oidc-webhook-authenticator/charts/runtime/values.yaml
+++ b/charts/oidc-webhook-authenticator/charts/runtime/values.yaml
@@ -33,7 +33,7 @@ webhookConfig:
 kubeconfig:
 
 auth:
-  # /readyz, /livez endpoints are always allowed
+  # /healthz, /readyz, /livez endpoints are always allowed
   # Kubeconfig to the target authentication and authorization cluster. In-cluster configuration will be used if not specified.
   # If automountServiceAccountToken is set to `true` then this value is required because in-cluster configuration will not work.
   kubeconfig:

--- a/charts/oidc-webhook-authenticator/charts/runtime/values.yaml
+++ b/charts/oidc-webhook-authenticator/charts/runtime/values.yaml
@@ -33,7 +33,7 @@ webhookConfig:
 kubeconfig:
 
 auth:
-  # /metrics, /readyz, /livez endpoints are always allowed
+  # /readyz, /livez endpoints are always allowed
   # Kubeconfig to the target authentication and authorization cluster. In-cluster configuration will be used if not specified.
   # If automountServiceAccountToken is set to `true` then this value is required because in-cluster configuration will not work.
   kubeconfig:

--- a/charts/oidc-webhook-authenticator/values.yaml
+++ b/charts/oidc-webhook-authenticator/values.yaml
@@ -58,7 +58,7 @@ runtime:
   kubeconfig:
 
   auth:
-    # /readyz, /livez endpoints are always allowed
+    # /healthz, /readyz, /livez endpoints are always allowed
     # Kubeconfig to the target authentication and authorization cluster. In-cluster configuration will be used if not specified.
     # If automountServiceAccountToken is set to `true` then this value is required because in-cluster configuration will not work.
     kubeconfig:

--- a/charts/oidc-webhook-authenticator/values.yaml
+++ b/charts/oidc-webhook-authenticator/values.yaml
@@ -58,7 +58,7 @@ runtime:
   kubeconfig:
 
   auth:
-    # /metrics, /readyz, /livez endpoints are always allowed
+    # /readyz, /livez endpoints are always allowed
     # Kubeconfig to the target authentication and authorization cluster. In-cluster configuration will be used if not specified.
     # If automountServiceAccountToken is set to `true` then this value is required because in-cluster configuration will not work.
     kubeconfig:

--- a/cmd/oidc-webhook-authenticator/app/oidc_webhook_authenticator.go
+++ b/cmd/oidc-webhook-authenticator/app/oidc_webhook_authenticator.go
@@ -161,7 +161,10 @@ func newHandler(opts *options.Config, authWH *authentication.Webhook, scheme *ru
 
 	healthz.InstallReadyzHandler(pathRecorder, healthz.LogHealthz, healthz.PingHealthz)
 	healthz.InstallLivezHandler(pathRecorder, healthz.LogHealthz, healthz.PingHealthz)
-	pathRecorder.Handle(metricsPath, promhttp.Handler())
+
+	metricsHandler := promhttp.Handler()
+	metricsHandler = withAuthz(metricsHandler, opts)
+	pathRecorder.Handle(metricsPath, metricsHandler)
 
 	authHandler := authWH.Build()
 	authHandler = withAuthz(authHandler, opts)

--- a/cmd/oidc-webhook-authenticator/app/oidc_webhook_authenticator.go
+++ b/cmd/oidc-webhook-authenticator/app/oidc_webhook_authenticator.go
@@ -159,6 +159,7 @@ func newHandler(opts *options.Config, authWH *authentication.Webhook, scheme *ru
 	)
 	pathRecorder := mux.NewPathRecorderMux("oidc-webhook-authenticator")
 
+	healthz.InstallHandler(pathRecorder, healthz.LogHealthz, healthz.PingHealthz)
 	healthz.InstallReadyzHandler(pathRecorder, healthz.LogHealthz, healthz.PingHealthz)
 	healthz.InstallLivezHandler(pathRecorder, healthz.LogHealthz, healthz.PingHealthz)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR reverts some of the changes done with #103. The `/metrics` endpoint will requires authz. If needed to be scraped without authz then it can be skipped during authorization and anonymous auth can be enabled as well. This PR also brings back the `/healthz` endpoint.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
@vpnachev I will unpdate the release notes of #103 if we merge this PR.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
