### PR TITLE
Additional logging during token verification

### DIFF
--- a/cmd/oidc-webhook-authenticator/app/oidc_webhook_authenticator.go
+++ b/cmd/oidc-webhook-authenticator/app/oidc_webhook_authenticator.go
@@ -40,7 +40,7 @@ import (
 func NewOIDCWebhookAuthenticatorCommand(ctx context.Context) *cobra.Command {
 	opt := options.NewOptions()
 	conf := &options.Config{}
-	settupLogger := ctrl.Log.WithName("setup")
+	setupLogger := ctrl.Log.WithName("setup")
 	zapOpts := zap.Options{}
 
 	cmd := &cobra.Command{
@@ -53,14 +53,14 @@ func NewOIDCWebhookAuthenticatorCommand(ctx context.Context) *cobra.Command {
 
 			err := opt.ApplyTo(conf)
 			if err != nil {
-				settupLogger.Error(err, "cannot apply options")
+				setupLogger.Error(err, "cannot apply options")
 
 				os.Exit(1)
 			}
 
-			err = run(ctx, conf, settupLogger)
+			err = run(ctx, conf, setupLogger)
 			if err != nil {
-				settupLogger.Error(err, "cannot run")
+				setupLogger.Error(err, "cannot run")
 
 				os.Exit(1)
 			}

--- a/cmd/oidc-webhook-authenticator/app/oidc_webhook_authenticator.go
+++ b/cmd/oidc-webhook-authenticator/app/oidc_webhook_authenticator.go
@@ -41,12 +41,15 @@ func NewOIDCWebhookAuthenticatorCommand(ctx context.Context) *cobra.Command {
 	opt := options.NewOptions()
 	conf := &options.Config{}
 	settupLogger := ctrl.Log.WithName("setup")
+	zapOpts := zap.Options{}
 
 	cmd := &cobra.Command{
 		Use: "oidc-webhook-authenticator",
 		Run: func(cmd *cobra.Command, args []string) {
 			verflag.PrintAndExitIfRequested()
 			cliflag.PrintFlags(cmd.Flags())
+
+			ctrl.SetLogger(zap.New(zap.UseFlagOptions(&zapOpts)))
 
 			err := opt.ApplyTo(conf)
 			if err != nil {
@@ -81,10 +84,8 @@ func NewOIDCWebhookAuthenticatorCommand(ctx context.Context) *cobra.Command {
 	opt.AddFlags(fs)
 	globalflag.AddGlobalFlags(fs, "global")
 
-	opts := zap.Options{}
-	opts.BindFlags(goflag.CommandLine)
+	zapOpts.BindFlags(goflag.CommandLine)
 	fs.AddGoFlagSet(goflag.CommandLine)
-	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
 	return cmd
 }

--- a/config/samples/deployment.yaml
+++ b/config/samples/deployment.yaml
@@ -95,6 +95,7 @@ spec:
         args:
         - --tls-cert-file=/var/run/certs/tls.crt
         - --tls-private-key-file=/var/run/certs/tls.key
+        - --zap-log-level=10
         - --v=6
         resources:
           requests:


### PR DESCRIPTION
**What this PR does / why we need it**:
Correctly applies zap logger options.
Adds additional logs w.r.t. token verification that can be used during debugging sessions.

**Which issue(s) this PR fixes**:
Fixes #110 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Zap logger flags are now properly applied to the logging configuration.
```

```feature operator
Additional logs regarding token verification can be enabled by setting `--zap-log-level` >= 10. These logs can reveal the reason behind token verification failure and can be useful in debugging scenarios.
```
