### PR TITLE
Allow configuration of additional Service annotations

### DIFF
--- a/charts/oidc-webhook-authenticator/charts/runtime/templates/service.yaml
+++ b/charts/oidc-webhook-authenticator/charts/runtime/templates/service.yaml
@@ -11,6 +11,10 @@ metadata:
     app.kubernetes.io/name: {{ include "oidc-webhook-authenticator.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+  {{- if .Values.additionalAnnotations.service }}
+  annotations:
+    {{- toYaml .Values.additionalAnnotations.service | trim | nindent 4 }}
+  {{- end }}
 spec:
   type: ClusterIP
   selector:

--- a/charts/oidc-webhook-authenticator/charts/runtime/values.yaml
+++ b/charts/oidc-webhook-authenticator/charts/runtime/values.yaml
@@ -63,3 +63,6 @@ apiAudiences: []
 additionalLabels:
   hpa: {}
   deployment: {}
+
+additionalAnnotations:
+  service: {}

--- a/charts/oidc-webhook-authenticator/values.yaml
+++ b/charts/oidc-webhook-authenticator/values.yaml
@@ -88,3 +88,5 @@ runtime:
   additionalLabels:
     deployment: {}
     hpa: {}
+  additionalAnnotations:
+    service: {}


### PR DESCRIPTION
**What this PR does / why we need it**:
Allow configuration of additional Service annotations

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
It is now possible to configure additional annotations for the `Service` in the Helm chart via `additionalAnnotations.service`.
```
