### PR TITLE
Ability to configure clusterIP for OWA service

### DIFF
--- a/charts/oidc-webhook-authenticator/charts/runtime/templates/cm-certificate.yaml
+++ b/charts/oidc-webhook-authenticator/charts/runtime/templates/cm-certificate.yaml
@@ -17,6 +17,10 @@ spec:
   - {{ include "oidc-webhook-authenticator.name" . }}.{{ .Release.Namespace }}.svc
   - {{ include "oidc-webhook-authenticator.name" . }}.{{ .Release.Namespace }}.svc.cluster
   - {{ include "oidc-webhook-authenticator.name" . }}.{{ .Release.Namespace }}.svc.cluster.local
+  {{- if .Values.clusterIP }}
+  ipAddresses:
+  - {{ .Values.clusterIP }}
+  {{- end }}
   issuerRef:
     kind: Issuer
     name: {{ include "oidc-webhook-authenticator.name" . }}-issuer

--- a/charts/oidc-webhook-authenticator/charts/runtime/templates/cm-certificate.yaml
+++ b/charts/oidc-webhook-authenticator/charts/runtime/templates/cm-certificate.yaml
@@ -15,7 +15,6 @@ spec:
   - {{ include "oidc-webhook-authenticator.name" . }}
   - {{ include "oidc-webhook-authenticator.name" . }}.{{ .Release.Namespace }}
   - {{ include "oidc-webhook-authenticator.name" . }}.{{ .Release.Namespace }}.svc
-  - {{ include "oidc-webhook-authenticator.name" . }}.{{ .Release.Namespace }}.svc.cluster
   - {{ include "oidc-webhook-authenticator.name" . }}.{{ .Release.Namespace }}.svc.cluster.local
   {{- if .Values.clusterIP }}
   ipAddresses:

--- a/charts/oidc-webhook-authenticator/charts/runtime/templates/service.yaml
+++ b/charts/oidc-webhook-authenticator/charts/runtime/templates/service.yaml
@@ -17,6 +17,9 @@ metadata:
   {{- end }}
 spec:
   type: ClusterIP
+  {{- if .Values.clusterIP }}
+  clusterIP: {{ .Values.clusterIP }}
+  {{- end }}
   selector:
     app.kubernetes.io/name: {{ include "oidc-webhook-authenticator.name" . }}
   ports:

--- a/charts/oidc-webhook-authenticator/charts/runtime/values.yaml
+++ b/charts/oidc-webhook-authenticator/charts/runtime/values.yaml
@@ -66,3 +66,6 @@ additionalLabels:
 
 additionalAnnotations:
   service: {}
+
+# If set the oidc-webhook-authenticator service will have this cluster IP assigned
+clusterIP: ""

--- a/charts/oidc-webhook-authenticator/values.yaml
+++ b/charts/oidc-webhook-authenticator/values.yaml
@@ -90,3 +90,6 @@ runtime:
     hpa: {}
   additionalAnnotations:
     service: {}
+
+  # If set the oidc-webhook-authenticator service will have this cluster IP assigned
+  clusterIP: "" 


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #116

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
It is now possible to configure a `clusterIP` for the OWA service through the helm charts by setting `.Values.clusterIP`.
```
