### PR TITLE
Implement support for imagePullSecrets

### DIFF
--- a/charts/oidc-webhook-authenticator/charts/runtime/templates/deployment.yaml
+++ b/charts/oidc-webhook-authenticator/charts/runtime/templates/deployment.yaml
@@ -43,6 +43,10 @@ spec:
         {{- toYaml .Values.additionalLabels.deployment | trim | nindent 8 }}
         {{- end }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ include "oidc-webhook-authenticator.name" . }}
       automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
       securityContext:

--- a/charts/oidc-webhook-authenticator/charts/runtime/values.yaml
+++ b/charts/oidc-webhook-authenticator/charts/runtime/values.yaml
@@ -8,6 +8,7 @@ image:
   repository: eu.gcr.io/gardener-project/gardener/oidc-webhook-authenticator
   tag: latest
   pullPolicy: IfNotPresent
+imagePullSecrets: []
 
 autoscaling:
   hpa:

--- a/charts/oidc-webhook-authenticator/values.yaml
+++ b/charts/oidc-webhook-authenticator/values.yaml
@@ -33,6 +33,7 @@ runtime:
     repository: eu.gcr.io/gardener-project/gardener/oidc-webhook-authenticator
     tag: latest
     pullPolicy: IfNotPresent
+  imagePullSecrets: []
 
   autoscaling:
     hpa:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the support for setting imagePullSecrets which allows to pull the desired image from a private registry.

**Which issue(s) this PR fixes**:
Fixes #130

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
The helm chart can now be configured to pull the webhook image from a private registry through the use of the imagePullSecrets field.
```
