### PR TITLE
Implement deployment with client certificate

### DIFF
--- a/charts/oidc-webhook-authenticator/charts/application/templates/cluster-role-client.yaml
+++ b/charts/oidc-webhook-authenticator/charts/application/templates/cluster-role-client.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2023 Idiap Research Institute
+#
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if and .Values.global.certManager.enabled .Values.global.certManager.generateClientCertificate }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "oidc-webhook-authenticator.name" . }}-client
+  labels:
+    app.kubernetes.io/name: {{ include "oidc-webhook-authenticator.name" . }}
+rules:
+- nonResourceURLs:
+  - /validate-token
+  verbs:
+  - post
+{{- end}}

--- a/charts/oidc-webhook-authenticator/charts/application/templates/clusterrole-binding-client.yaml
+++ b/charts/oidc-webhook-authenticator/charts/application/templates/clusterrole-binding-client.yaml
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: 2023 Idiap Research Institute
+#
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if and .Values.global.certManager.enabled .Values.global.certManager.generateClientCertificate }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "oidc-webhook-authenticator.name" . }}-client
+  labels:
+    app.kubernetes.io/name: {{ include "oidc-webhook-authenticator.name" . }}
+
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "oidc-webhook-authenticator.name" . }}-client
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: {{ include "oidc-webhook-authenticator.name" . }}-client
+{{- end}}

--- a/charts/oidc-webhook-authenticator/charts/runtime/templates/cm-client-certificate.yaml
+++ b/charts/oidc-webhook-authenticator/charts/runtime/templates/cm-client-certificate.yaml
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: 2023 Idiap Research Institute
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Certificate to be configured in webhook config as client authentication
+
+{{- if and .Values.global.certManager.enabled .Values.global.certManager.generateClientCertificate }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "oidc-webhook-authenticator.name" . }}-client
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ include "oidc-webhook-authenticator.name" . }}
+spec:
+  commonName: {{ include "oidc-webhook-authenticator.name" . }}-client
+  issuerRef:
+    kind: Issuer
+    name: {{ include "oidc-webhook-authenticator.name" . }}-issuer
+  secretName: oidc-webhook-client
+  duration: {{ .Values.webhookConfig.clientCertificateDuration }}
+  usages:
+  - client auth
+{{- end }}

--- a/charts/oidc-webhook-authenticator/charts/runtime/templates/deployment.yaml
+++ b/charts/oidc-webhook-authenticator/charts/runtime/templates/deployment.yaml
@@ -76,6 +76,9 @@ spec:
         args:
         - --tls-cert-file=/var/run/oidc-webhook-authenticator/tls/tls.crt
         - --tls-private-key-file=/var/run/oidc-webhook-authenticator/tls/tls.key
+        {{- if and .Values.global.certManager.enabled .Values.global.certManager.generateClientCertificate }}
+        - --client-ca-file=/var/run/oidc-webhook-authenticator/tls/ca.crt
+        {{- end}}
         {{- if .Values.kubeconfig }}
         - --kubeconfig=/var/run/oidc-webhook-authenticator/kubeconfig/kubeconfig
         {{- end }}

--- a/charts/oidc-webhook-authenticator/templates/NOTES.txt
+++ b/charts/oidc-webhook-authenticator/templates/NOTES.txt
@@ -1,0 +1,21 @@
+Thank you for installing {{ .Chart.Name }}.
+
+Your release is named {{ .Release.Name }}.
+
+To learn more about the release, try:
+
+  $ helm status {{ .Release.Name }}
+  $ helm get all {{ .Release.Name }}
+
+{{ if and .Values.global.certManager.enabled .Values.global.certManager.generateClientCertificate }}
+Your client certificate data can be retrieved using the following commands:
+
+  $ kubectl -n {{ .Release.Namespace }} get secrets oidc-webhook-client -o jsonpath='{.data.ca\.crt}' | base64 -d | pbcopy
+  $ kubectl -n {{ .Release.Namespace }} get secrets oidc-webhook-client -o jsonpath='{.data.tls\.crt}' | base64 -d | pbcopy
+  $ kubectl -n {{ .Release.Namespace }} get secrets oidc-webhook-client -o jsonpath='{.data.tls\.key}' | base64 -d | pbcopy
+
+You can then use the data to create your webhook configuration either by using
+the data directly in the corresponding fields or store them on the host and use
+the path to it (see https://kubernetes.io/docs/reference/config-api/kubeconfig.v1/).
+
+{{- end }}

--- a/charts/oidc-webhook-authenticator/values.yaml
+++ b/charts/oidc-webhook-authenticator/values.yaml
@@ -5,6 +5,8 @@
 global:
   certManager:
     enabled: false
+    generateClientCertificate: true
+    clientCertificateDuration: 2160h # 90d
 
 application:
   enabled: true


### PR DESCRIPTION
**What this PR does / why we need it**:

Implement client certificate creation using cert-manager as part of the deployment process.

Doing so, one can directly have a usable certificate to connect to the webhook. The certificate, key and ca can be retrieved to be put in the webhook configuration using kubectl.

**Which issue(s) this PR fixes**:
Fixes #129

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Webhook operator can now automatically create a client certificate upon installation using the new `global.certManager.generateClientCertificate` attribute. The duration of the certificate can be controlled using `global.certManager.clientCertificateDuration` which defaults to 90 days.
```
