### PR TITLE
switch GCR -> Artifact-Registry

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -7,6 +7,8 @@ oidc-webhook-authenticator:
     traits:
       version:
         preprocess: inject-commit-hash
+      component_descriptor:
+        ocm_repository: europe-docker.pkg.dev/gardener-project/snapshots
       publish:
         oci-builder: docker-buildx
         platforms:
@@ -14,14 +16,16 @@ oidc-webhook-authenticator:
         - linux/arm64
         dockerimages:
           oidc-webhook-authenticator:
-            image: eu.gcr.io/gardener-project/gardener/oidc-webhook-authenticator
+            image: europe-docker.pkg.dev/gardener-project/snapshots/gardener/oidc-webhook-authenticator
             dockerfile: Dockerfile
             tag_template: ${EFFECTIVE_VERSION}
             tag_as_latest: false
   jobs:
     head-update:
       traits:
-        component_descriptor: ~
+        component_descriptor:
+          ocm_repository_mappings:
+            - repository: europe-docker.pkg.dev/gardener-project/releases
         draft_release: ~
         publish:
           dockerimages:
@@ -30,11 +34,12 @@ oidc-webhook-authenticator:
     pull-request:
       traits:
         pull-request: ~
-        component_descriptor: ~
     release:
       traits:
         version:
           preprocess: finalize
+        component_descriptor:
+          ocm_repository: europe-docker.pkg.dev/gardener-project/releases
         release:
           nextversion: bump_minor
         slack:
@@ -43,8 +48,8 @@ oidc-webhook-authenticator:
             internal_scp_workspace:
               channel_name: 'C9CEBQPGE' #sap-tech-gardener
               slack_cfg_name: 'scp_workspace'
-        component_descriptor: ~
         publish:
           dockerimages:
             oidc-webhook-authenticator:
+              image: europe-docker.pkg.dev/gardener-project/releases/gardener/oidc-webhook-authenticator
               tag_as_latest: false

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -3,9 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 oidc-webhook-authenticator:
-  template: default
   base_definition:
-    repo: ~
     traits:
       version:
         preprocess: inject-commit-hash
@@ -16,7 +14,6 @@ oidc-webhook-authenticator:
         - linux/arm64
         dockerimages:
           oidc-webhook-authenticator:
-            registry: gcr-readwrite
             image: eu.gcr.io/gardener-project/gardener/oidc-webhook-authenticator
             dockerfile: Dockerfile
             tag_template: ${EFFECTIVE_VERSION}

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ An overview of the flow:
 Docker images are available [here](https://console.cloud.google.com/gcr/images/gardener-project/EU/gardener/oidc-webhook-authenticator) or you can choose to pull the latest pre-release version with the following command:
 
 ```text
-docker pull eu.gcr.io/gardener-project/gardener/oidc-webhook-authenticator:latest
+docker pull europe-docker.pkg.dev/gardener-project/public/gardener/oidc-webhook-authenticator:latest
 ```
 
 ## Local development

--- a/charts/oidc-webhook-authenticator/charts/runtime/values.yaml
+++ b/charts/oidc-webhook-authenticator/charts/runtime/values.yaml
@@ -5,7 +5,7 @@
 replicaCount: 1
 
 image:
-  repository: eu.gcr.io/gardener-project/gardener/oidc-webhook-authenticator
+  repository: europe-docker.pkg.dev/gardener-project/public/gardener/oidc-webhook-authenticator
   tag: latest
   pullPolicy: IfNotPresent
 imagePullSecrets: []

--- a/charts/oidc-webhook-authenticator/values.yaml
+++ b/charts/oidc-webhook-authenticator/values.yaml
@@ -30,7 +30,7 @@ runtime:
   replicaCount: 1
 
   image:
-    repository: eu.gcr.io/gardener-project/gardener/oidc-webhook-authenticator
+    repository: europe-docker.pkg.dev/gardener-project/public/gardener/oidc-webhook-authenticator
     tag: latest
     pullPolicy: IfNotPresent
   imagePullSecrets: []


### PR DESCRIPTION
GCR has been deprecated [0] in favour of Artifact-Registry.

Thus, change push-targets for OCI-Images:

- europe-docker.pkg.dev/gardener-project/snapshots for snapshots
- europe-docker.pkg.dev/gardener-project/releases for releases
- europe-docker.pkg.dev/gardener-project/public for combined view of snapshots + releases

[0]
https://cloud.google.com/artifact-registry/docs/transition/transition-from-gcr


**Release note**:

```breaking operator
Change OCI Image Registry from GCR (`eu.gcr.io/gardener-project`) to Artifact-Registry (`europe-docker.pkg.dev/gardener-project/releases`). Users should update their references.

```
