### PR TITLE
Increase default resync period to 30min

### DIFF
--- a/charts/oidc-webhook-authenticator/charts/runtime/values.yaml
+++ b/charts/oidc-webhook-authenticator/charts/runtime/values.yaml
@@ -51,7 +51,7 @@ server:
   address: ""
   port: 10443
 
-resyncPeriod: 10m
+resyncPeriod: 30m
 resources:
   requests:
     cpu: 100m

--- a/charts/oidc-webhook-authenticator/values.yaml
+++ b/charts/oidc-webhook-authenticator/values.yaml
@@ -75,7 +75,7 @@ runtime:
     address: ""
     port: 10443
 
-  resyncPeriod: 10m
+  resyncPeriod: 30m
   resources:
     requests:
       cpu: 100m

--- a/cmd/oidc-webhook-authenticator/app/options/options.go
+++ b/cmd/oidc-webhook-authenticator/app/options/options.go
@@ -109,7 +109,7 @@ func (s *resyncPeriod) AddFlags(fs *pflag.FlagSet) {
 		return
 	}
 
-	fs.DurationVar(&s.Duration, "resync-period", time.Minute*10, "resync period")
+	fs.DurationVar(&s.Duration, "resync-period", 30*time.Minute, "resync period")
 }
 
 func (s *resyncPeriod) ApplyTo(c *resyncPeriod) error {

--- a/controllers/authentication/openidconnect_controller.go
+++ b/controllers/authentication/openidconnect_controller.go
@@ -185,7 +185,7 @@ func (r *OpenIDConnectReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: 50,
 			RateLimiter: workqueue.NewMaxOfRateLimiter(
-				workqueue.NewItemExponentialFailureRateLimiter(5*time.Second, 10*time.Second),
+				workqueue.NewItemExponentialFailureRateLimiter(5*time.Second, time.Minute),
 				&workqueue.BucketRateLimiter{Limiter: rate.NewLimiter(rate.Limit(10), 100)},
 			),
 		}).


### PR DESCRIPTION
**What this PR does / why we need it**:
Part of https://github.com/gardener/oidc-webhook-authenticator/issues/154

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The default resync period between reconciliations of `openidconnect`s is increased to 30min.
```
