### PR TITLE
Enable gosec for SAST scans

### DIFF
--- a/.ci/check
+++ b/.ci/check
@@ -20,6 +20,11 @@ cd "${SOURCE_PATH}"
 go vet ./...
 go fmt ./...
 
+go install github.com/securego/gosec/v2/cmd/gosec@v2.21.4
+
+echo "> Run SAST scan"
+make sast
+
 curl -s "https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3" | bash -s -- --version 'v3.5.4'
 
 echo "> Lint helm charts"

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -4,6 +4,13 @@
 
 oidc-webhook-authenticator:
   base_definition:
+    repo:
+      source_labels:
+      - name: cloud.gardener.cnudie/dso/scanning-hints/source_analysis/v1
+        value:
+          policy: skip
+          comment: |
+            We use gosec for sast scanning, see attached log.
     traits:
       version:
         preprocess: inject-commit-hash
@@ -42,6 +49,16 @@ oidc-webhook-authenticator:
           ocm_repository: europe-docker.pkg.dev/gardener-project/releases
         release:
           nextversion: bump_minor
+          assets:
+          - type: build-step-log
+            step_name: verify
+            purposes:
+            - lint
+            - sast
+            - gosec
+            comment: |
+              We use gosec (linter) for SAST scans, see: https://github.com/securego/gosec.
+              Enabled by https://github.com/gardener/oidc-webhook-authenticator/pull/165
         slack:
           default_channel: 'internal_scp_workspace'
           channel_cfgs:

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ dive.log
 /tmp
 
 /helm-templates
+
+# gosec
+gosec-report.sarif

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -5,7 +5,6 @@ run:
 linters:
   enable:
   - gocritic
-  - gosec
   - revive
 
 issues:

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,14 @@ fmt: ## Run go fmt against code.
 vet: ## Run go vet against code.
 	go vet ./...
 
+.PHONY: sast ## Run Static Application Security Testing scan with gosec
+sast:
+	@./hack/sast.sh
+
+.PHONY: sast-report ## Run Static Application Security Testing scan with gosec and write report to `gosec-report.sarif`
+sast-report:
+	@./hack/sast.sh --gosec-report true
+
 start-dev-container: tools-image ## Run go vet against code.
 	docker run --rm --tty --interactive --name=odic-dev-container -v $(shell pwd):/workspace --workdir /workspace tools:latest /bin/bash
 

--- a/hack/sast.sh
+++ b/hack/sast.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+#
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+root_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." &> /dev/null && pwd )"
+
+gosec_report="false"
+gosec_report_parse_flags=""
+
+parse_flags() {
+  while test $# -gt 1; do
+    case "$1" in
+      --gosec-report)
+        shift; gosec_report="$1"
+        ;;
+      *)
+        echo "Unknown argument: $1"
+        exit 1
+        ;;
+    esac
+    shift
+  done
+}
+
+parse_flags "$@"
+
+echo "> Running gosec"
+gosec --version
+if [[ "$gosec_report" != "false" ]]; then
+  echo "Exporting report to $root_dir/gosec-report.sarif"
+  gosec_report_parse_flags="-track-suppressions -fmt=sarif -out=gosec-report.sarif -stdout"
+fi
+
+gosec  $gosec_report_parse_flags ./...

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -11,7 +11,7 @@ func NotFound() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusNotFound)
-		w.Write([]byte(`{"code":404,"message":"not found"}`)) //nolint:errcheck,gosec
+		w.Write([]byte(`{"code":404,"message":"not found"}`)) // #nosec G104
 	})
 }
 
@@ -19,6 +19,6 @@ func NotFound() http.Handler {
 func Ping() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(`{"code":200,"message":"ok"}`)) //nolint:errcheck,gosec
+		w.Write([]byte(`{"code":200,"message":"ok"}`)) // #nosec G104
 	})
 }

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -11,6 +11,7 @@ func NotFound() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusNotFound)
+		//nolint:errcheck
 		w.Write([]byte(`{"code":404,"message":"not found"}`)) // #nosec G104
 	})
 }
@@ -19,6 +20,7 @@ func NotFound() http.Handler {
 func Ping() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
+		//nolint:errcheck
 		w.Write([]byte(`{"code":200,"message":"ok"}`)) // #nosec G104
 	})
 }

--- a/test/integration/env/oidc_webhook_server.go
+++ b/test/integration/env/oidc_webhook_server.go
@@ -136,7 +136,7 @@ func (s *oidcWebhookServer) configureDefaults(rootDir string) error {
 
 func (s *oidcWebhookServer) start() error {
 	s.exited = make(chan struct{})
-	command := exec.Command(s.Path, s.Args...) //nolint:gosec
+	command := exec.Command(s.Path, s.Args...) // #nosec G204
 	session, err := gexec.Start(command, s.Out, s.Err)
 	if err != nil {
 		return err

--- a/test/integration/mock/identityserver.go
+++ b/test/integration/mock/identityserver.go
@@ -197,6 +197,7 @@ func (idp *OIDCIdentityServer) buildWellKnownHandler() func(w http.ResponseWrite
 		wellKnown := fmt.Sprintf(wellKnownResponseTemplate, host)
 		w.Header().Set("Content-Type", "application/json")
 		w.Header().Set("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
+		//nolint:errcheck
 		w.Write([]byte(wellKnown)) // #nosec G104
 	}
 }
@@ -211,6 +212,7 @@ func (idp *OIDCIdentityServer) buildJWKSHandler() func(w http.ResponseWriter, _ 
 
 		w.Header().Set("Content-Type", "application/json")
 		w.Header().Set("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
+		//nolint:errcheck
 		w.Write(jwks) // #nosec G104
 	}
 }

--- a/test/integration/mock/identityserver.go
+++ b/test/integration/mock/identityserver.go
@@ -197,7 +197,7 @@ func (idp *OIDCIdentityServer) buildWellKnownHandler() func(w http.ResponseWrite
 		wellKnown := fmt.Sprintf(wellKnownResponseTemplate, host)
 		w.Header().Set("Content-Type", "application/json")
 		w.Header().Set("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
-		w.Write([]byte(wellKnown)) //nolint:errcheck,gosec
+		w.Write([]byte(wellKnown)) // #nosec G104
 	}
 }
 
@@ -211,7 +211,7 @@ func (idp *OIDCIdentityServer) buildJWKSHandler() func(w http.ResponseWriter, _ 
 
 		w.Header().Set("Content-Type", "application/json")
 		w.Header().Set("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
-		w.Write(jwks) //nolint:errcheck,gosec
+		w.Write(jwks) // #nosec G104
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Enable `gosec` for SAST scans

**Which issue(s) this PR fixes**:
Fixes #164 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->


```other developer
`gosec` is made available for SAST(static application security testing), it can be run with `make sast` or `make sast-report`. 
```
