### PR TITLE
Use correct step_name for SAST reporting

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -51,7 +51,7 @@ oidc-webhook-authenticator:
           nextversion: bump_minor
           assets:
           - type: build-step-log
-            step_name: verify
+            step_name: check
             purposes:
             - lint
             - sast


### PR DESCRIPTION
**What this PR does / why we need it**:
The step should be called check ([ref](https://github.com/gardener/oidc-webhook-authenticator/blob/master/.ci/check))
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
