### PR TITLE
Statically configure component responsibles 

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -27,6 +27,13 @@ oidc-webhook-authenticator:
             dockerfile: Dockerfile
             tag_template: ${EFFECTIVE_VERSION}
             tag_as_latest: false
+            resource_labels:
+            - name: 'cloud.gardener.cnudie/responsibles'
+              value:
+              - type: 'githubUser'
+                username: 'dimityrmirchev'
+              - type: 'githubUser'
+                username: 'vpnachev'
   jobs:
     head-update:
       traits:


### PR DESCRIPTION
**What this PR does / why we need it**:
Statically configure component responsibles 

**Which issue(s) this PR fixes**:
Similar to https://github.com/gardener/gardener-extension-shoot-oidc-service/pull/269

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
