### PR TITLE
Forbid container privilege escalations

### DIFF
--- a/charts/oidc-webhook-authenticator/charts/runtime/templates/deployment.yaml
+++ b/charts/oidc-webhook-authenticator/charts/runtime/templates/deployment.yaml
@@ -109,6 +109,8 @@ spec:
           periodSeconds: 15
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
+        securityContext:
+          allowPrivilegeEscalation: false
         volumeMounts:
         - name: tls
           mountPath: /var/run/oidc-webhook-authenticator/tls


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR sets the `securityContext.allowPrivilegeEscalation` field to `false` for every container, which does not have `securityContext.Privileged` set to `true` or one of `CAP_SYS_ADMIN/SYS_ADMIN` capabilities added.

**Which issue(s) this PR fixes**:
Part of gardener/gardener#11139

**Special notes for your reviewer**:
NONE

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Containers, which do not require privilege escalations, now forbid privilege escalations explicitly.
```
