### PR TITLE
Tag releases as latest

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,6 +10,12 @@ on:
         description: |
           The build mode to use. It can be either `snapshot` or `release`.
           Will affect effective version calculation, as well as target-oci-registry.
+      extra-tags:
+        required: false
+        type: string
+        description: |
+          A comma-separated list of additional tags to set. Existing tags will be updated.
+          Commonly used to reset `latest`-tag.
 
 jobs:
   prepare:
@@ -38,6 +44,7 @@ jobs:
     with:
       name: ${{ matrix.args.name }}
       version: ${{ needs.prepare.outputs.version }}
+      extra-tags: ${{ inputs.extra-tags }}
       target: ${{ matrix.args.target }}
       oci-registry: ${{ needs.prepare.outputs.oci-registry }}
       oci-repository: ${{ matrix.args.oci-repository }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,6 +18,7 @@ jobs:
       packages: write
     with:
       mode: release
+      extra-tags: latest
 
   release-to-github-and-bump:
     uses: gardener/cc-utils/.github/workflows/release.yaml@master

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ It adds the following extra information, that can be used by custom authorizers 
 Docker images are available [here](https://console.cloud.google.com/gcr/images/gardener-project/EU/gardener/oidc-webhook-authenticator) or you can choose to pull the latest pre-release version with the following command:
 
 ```text
-docker pull europe-docker.pkg.dev/gardener-project/public/gardener/oidc-webhook-authenticator:latest
+docker pull europe-docker.pkg.dev/gardener-project/releases/gardener/oidc-webhook-authenticator:latest
 ```
 
 ## Local development

--- a/charts/oidc-webhook-authenticator/charts/runtime/values.yaml
+++ b/charts/oidc-webhook-authenticator/charts/runtime/values.yaml
@@ -5,7 +5,7 @@
 replicaCount: 1
 
 image:
-  repository: europe-docker.pkg.dev/gardener-project/public/gardener/oidc-webhook-authenticator
+  repository: europe-docker.pkg.dev/gardener-project/releases/gardener/oidc-webhook-authenticator
   tag: latest
   pullPolicy: IfNotPresent
 imagePullSecrets: []

--- a/charts/oidc-webhook-authenticator/values.yaml
+++ b/charts/oidc-webhook-authenticator/values.yaml
@@ -26,7 +26,7 @@ runtime:
   replicaCount: 1
 
   image:
-    repository: europe-docker.pkg.dev/gardener-project/public/gardener/oidc-webhook-authenticator
+    repository: europe-docker.pkg.dev/gardener-project/releases/gardener/oidc-webhook-authenticator
     tag: latest
     pullPolicy: IfNotPresent
   imagePullSecrets: []


### PR DESCRIPTION
**What this PR does / why we need it**:
`europe-docker.pkg.dev/gardener-project/public/gardener/oidc-webhook-authenticator` is not used any more. Let's default the chart to the release repository + tag releases as latest.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
