### PR TITLE
Update go to version 1.25.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Build the manager binary
-FROM golang:1.24.5 AS builder
+FROM golang:1.25.1 AS builder
 
 ARG TARGETARCH
 WORKDIR /workspace

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -4,7 +4,7 @@
 
 FROM registry.k8s.io/kube-apiserver:v1.33.2 AS kube-apiserver
 FROM quay.io/coreos/etcd:v3.5.21 AS etcd
-FROM golang:1.24.5 AS tools
+FROM golang:1.25.1 AS tools
 
 COPY --from=kube-apiserver /usr/local/bin/kube-apiserver /testbin/kube-apiserver
 COPY --from=etcd /usr/local/bin/etcd /testbin/etcd


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
OWA is now built using go version 1.25.1.
```
