### PR TITLE
Run tests as part of the `run-tests` step in GHA

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,6 +22,7 @@ jobs:
   oci-images:
     name: Build OCI-Images
     needs:
+      - verify
       - prepare
     permissions:
       contents: read
@@ -119,3 +120,29 @@ jobs:
                 - name: gardener.cloud/purposes
                   value:
                     - test
+
+  oci-images-summary:
+    name: OCI Images Summary
+    runs-on: ubuntu-latest
+    needs:
+    - oci-images
+    if: ${{ always() }}  # Ensures this job runs even if the matrix partially fails
+    permissions:
+      contents: read
+    steps:
+      - name: Fail if OCI matrix failed
+        if: ${{ needs.oci-images.result != 'success' }}
+        run: exit 1
+
+  helmcharts-summary:
+    name: Helm Charts Summary
+    runs-on: ubuntu-latest
+    needs:
+    - helmcharts
+    if: ${{ always() }}  # Ensures this job runs even if the matrix partially fails
+    permissions:
+      contents: read
+    steps:
+      - name: Fail if Helm Charts matrix failed
+        if: ${{ needs.helmcharts.result != 'success' }}
+        run: exit 1

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -78,12 +78,13 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: '1.25'
       - uses: gardener/cc-utils/.github/actions/trusted-checkout@master
       - name: run-test
         shell: bash
         run: |
           set -eu
+          .ci/test
           mkdir /tmp/blobs.d
           .ci/check |& tee /tmp/blobs.d/verify-log.txt
           # verify calls `make sast-report`, which generates `gosec-report.sarif`


### PR DESCRIPTION
**What this PR does / why we need it**:
Run tests as part of the `run-tests` step in GHA

Also updates the go used to run the tests,  adds helmcharts and oci-image summary jobs, and requires `verify` step to succeed before building the oci-images

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
GHA build workflow now also runs the tests.
```
