### PR TITLE
Rename Non-Release GHA workflow

### DIFF
--- a/.github/workflows/non-release.yaml
+++ b/.github/workflows/non-release.yaml
@@ -1,9 +1,9 @@
-name: Build
+name: Non-Release
 on:
   push:
     branches:
       - master
-      - releases/**
+      - releases-v*
   pull_request:
 
 jobs:


### PR DESCRIPTION
**What this PR does / why we need it**:
Rename Non-Release GHA workflow

Also change release branches patter to what is actually used.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
