### PR TITLE
dependabot: Allow more gomod deps to be updated

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -7,7 +7,13 @@ updates:
   open-pull-requests-limit: 5
   allow:
   - dependency-name: "k8s.io/.*"
-  - dependency-name: "sigs.k8s.io/controller-runtime"
+  - dependency-name: "sigs.k8s.io/.*"
+  - dependency-name: "golang.org/x/.*"
+  - dependency-name: "github.com/go-jose/.*"
+  - dependency-name: "github.com/coreos/go-oidc"
+  - dependency-name: "github.com/coreos/go-oidc/v3"
+  - dependency-name: "github.com/onsi/.*"
+  - dependency-name: "github.com/prometheus/.*"
   labels:
   - kind/enhancement
 - package-ecosystem: docker


### PR DESCRIPTION
**What this PR does / why we need it**:
dependabot: Allow more gomod deps to be updated

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```

/kind enhancement
/area dev-productivity 
