### PR TITLE
[gha] Use 'stable' go version for the setup-go action

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -79,7 +79,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version: stable
       - uses: gardener/cc-utils/.github/actions/trusted-checkout@v1
       - name: run-test
         shell: bash


### PR DESCRIPTION
**What this PR does / why we need it**:
Use 'stable' go version for the setup-go action. This is helpful when the go toolchain version is changed, e.g. in go.mod, then the gh action does not need to be explicitly updated.

/kind enhancement

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
